### PR TITLE
Add keepalive functionality for C programs that utilize glib mainloop

### DIFF
--- a/examples-glib/Makefile
+++ b/examples-glib/Makefile
@@ -1,0 +1,57 @@
+# ----------------------------------------------------------- -*- mode: sh -*-
+# List of targets to build
+# ----------------------------------------------------------------------------
+
+TARGETS += block-suspend
+TARGETS += keep-display-on
+TARGETS += periodic-wakeup
+TARGETS += simple-timer-wakeup
+
+# ----------------------------------------------------------------------------
+# Top level targets
+# ----------------------------------------------------------------------------
+
+.PHONY: build install clean distclean mostlyclean
+
+build:: $(TARGETS)
+
+install:: build
+
+clean:: mostlyclean
+	$(RM) $(TARGETS)
+
+distclean:: clean
+
+mostlyclean::
+	$(RM) *.o *~ *.bak
+
+# ----------------------------------------------------------------------------
+# Default flags
+# ----------------------------------------------------------------------------
+
+CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -D_FILE_OFFSET_BITS=64
+
+CFLAGS   += -Wall
+CFLAGS   += -Os
+CFLAGS   += -std=c99
+CFLAGS   += -g
+
+LDFLAGS  += -g
+
+LDLIBS   += -Wl,--as-needed
+
+# ----------------------------------------------------------------------------
+# Flags from pkg-config
+# ----------------------------------------------------------------------------
+
+PKG_NAMES  += glib-2.0
+PKG_NAMES  += dbus-1
+PKG_NAMES  += dbus-glib-1
+PKG_NAMES  += keepalive-glib
+
+PKG_CFLAGS := $(shell pkg-config --cflags $(PKG_NAMES))
+PKG_LDLIBS := $(shell pkg-config --libs   $(PKG_NAMES))
+
+CFLAGS     += $(PKG_CFLAGS)
+LDLIBS     += $(PKG_LDLIBS)

--- a/examples-glib/README
+++ b/examples-glib/README
@@ -1,0 +1,16 @@
+Note: The example source do not use headers from source tree, i.e.
+      libkeepalive-glib and libkeepalive-glib-devel packages need
+      to be installed - similarly to real applications that would
+      use the interfaces.
+
+block-suspend.c
+	Uses cpukeepalive_t to block suspend.
+
+keep-display-on.c
+	Uses displaykeepalive_t to block timer based display blanking.
+
+periodic-wakeup.c
+	Uses background_activity_t to periodically wake up from suspend.
+
+simple-timer-wakeup.c
+	Used g_timeout_add() lookalike functions to wake up from suspend.

--- a/examples-glib/block-suspend.c
+++ b/examples-glib/block-suspend.c
@@ -1,0 +1,100 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <dbus/dbus.h>
+#include <dbus/dbus-glib-lowlevel.h>
+#include <keepalive-glib/keepalive-cpukeepalive.h>
+
+#include <assert.h>
+
+#define failure(FMT, ARGS...) do {\
+    fprintf(stderr, "%s: "FMT"\n", __FUNCTION__, ## ARGS);\
+    exit(EXIT_FAILURE); \
+} while(0)
+
+static DBusConnection *system_bus = 0;
+static GMainLoop *mainloop_handle = 0;
+
+static void disconnect_from_systembus(void)
+{
+    if( system_bus )
+        dbus_connection_unref(system_bus), system_bus = 0;
+}
+
+static void connect_to_system_bus(void)
+{
+    DBusError err = DBUS_ERROR_INIT;
+    system_bus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+    if( !system_bus )
+        failure("%s: %s", err.name, err.message);
+    dbus_connection_setup_with_g_main(system_bus, 0);
+    dbus_error_free(&err);
+}
+
+static gboolean exit_timer_cb(gpointer aptr)
+{
+    g_main_loop_quit(mainloop_handle);
+    return FALSE;
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc, (void)argv;
+
+    mainloop_handle = g_main_loop_new(0, 0);
+
+    connect_to_system_bus();
+
+    /* Create cpu keepalive object */
+    cpukeepalive_t *cpukeepalive = cpukeepalive_new();
+
+    /* Schedule exit in 20 seconds */
+    g_timeout_add_seconds(20, exit_timer_cb, 0);
+
+    /* Start blocking suspend */
+    printf("BLOCK SUSPEND\n");
+    cpukeepalive_start(cpukeepalive);
+
+    /* Run mainloop (until timer expires) */
+    printf("ENTER MAINLOOP\n");
+    g_main_loop_run(mainloop_handle);
+    printf("LEAVE MAINLOOP\n");
+
+    /* Allow device to suspend again*/
+    printf("ALLOW SUSPEND\n");
+    cpukeepalive_stop(cpukeepalive);
+
+    /* Release cpu keepalive object */
+    cpukeepalive_unref(cpukeepalive);
+
+    disconnect_from_systembus();
+
+    g_main_loop_unref(mainloop_handle);
+    return 0;
+}

--- a/examples-glib/keep-display-on.c
+++ b/examples-glib/keep-display-on.c
@@ -1,0 +1,108 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <dbus/dbus.h>
+#include <dbus/dbus-glib-lowlevel.h>
+#include <keepalive-glib/keepalive-displaykeepalive.h>
+
+#include <assert.h>
+
+#define failure(FMT, ARGS...) do {\
+    fprintf(stderr, "%s: "FMT"\n", __FUNCTION__, ## ARGS);\
+    exit(EXIT_FAILURE); \
+} while(0)
+
+static DBusConnection *system_bus = 0;
+static GMainLoop *mainloop_handle = 0;
+
+static void disconnect_from_systembus(void)
+{
+    if( system_bus )
+        dbus_connection_unref(system_bus), system_bus = 0;
+}
+
+static void connect_to_system_bus(void)
+{
+    DBusError err = DBUS_ERROR_INIT;
+    system_bus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+    if( !system_bus )
+        failure("%s: %s", err.name, err.message);
+    dbus_connection_setup_with_g_main(system_bus, 0);
+    dbus_error_free(&err);
+}
+
+static gboolean exit_timer_cb(gpointer aptr)
+{
+    g_main_loop_quit(mainloop_handle);
+    return FALSE;
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc, (void)argv;
+
+    mainloop_handle = g_main_loop_new(0, 0);
+
+    connect_to_system_bus();
+
+    /* Create display keepalive object */
+    displaykeepalive_t *displaykeepalive = displaykeepalive_new();
+
+    /* Schedule exit in 2 minutes */
+    g_timeout_add_seconds(120, exit_timer_cb, 0);
+
+    /* Block automatic display dimming / blanking
+     *
+     * Note: This does not turn on the display
+     */
+    printf("BLOCK DISPLAY BLANKING\n");
+    displaykeepalive_start(displaykeepalive);
+
+    /* Run mainloop (until timer expires)
+     *
+     * Whenever the device is in a state where display is
+     * on and lockscreen is not shown, automatic display
+     * dimming/blanking does not happen.
+     */
+    printf("ENTER MAINLOOP\n");
+    g_main_loop_run(mainloop_handle);
+    printf("LEAVE MAINLOOP\n");
+
+    /* Allow automatic dimming / blanking to happen again */
+    printf("ALLOW DISPLAY BLANKING\n");
+    displaykeepalive_stop(displaykeepalive);
+
+    /* Release display keepalive object */
+    displaykeepalive_unref(displaykeepalive);
+
+    disconnect_from_systembus();
+
+    g_main_loop_unref(mainloop_handle);
+    return 0;
+}

--- a/examples-glib/periodic-wakeup.c
+++ b/examples-glib/periodic-wakeup.c
@@ -1,0 +1,173 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <glib.h>
+#include <dbus/dbus.h>
+#include <dbus/dbus-glib-lowlevel.h>
+#include <keepalive-glib/keepalive-backgroundactivity.h>
+
+#include <assert.h>
+
+#define failure(FMT, ARGS...) do {\
+    fprintf(stderr, "%s: "FMT"\n", __FUNCTION__, ## ARGS);\
+    exit(EXIT_FAILURE); \
+} while(0)
+
+static DBusConnection *system_bus = 0;
+static GMainLoop *mainloop_handle = 0;
+
+static void disconnect_from_systembus(void)
+{
+    if( system_bus )
+        dbus_connection_unref(system_bus), system_bus = 0;
+}
+
+static void connect_to_system_bus(void)
+{
+    DBusError err = DBUS_ERROR_INIT;
+    system_bus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+    if( !system_bus )
+        failure("%s: %s", err.name, err.message);
+    dbus_connection_setup_with_g_main(system_bus, 0);
+    dbus_error_free(&err);
+}
+
+static gboolean continue_cb(gpointer aptr)
+{
+    printf("%s()\n", __FUNCTION__);
+
+    background_activity_t *activity = aptr;
+
+    /* Suspend is unblocked, next iphb wakeup is scheduled */
+    background_activity_wait(activity);
+
+    return FALSE;
+}
+
+static gboolean stop_cb(gpointer aptr)
+{
+    printf("%s()\n", __FUNCTION__);
+
+    background_activity_t *activity = aptr;
+
+    /* Suspend is unblocked, no iphb wakeup is scheduled */
+    background_activity_stop(activity);
+
+    printf("EXIT MAINLOOP\n");
+    g_main_loop_quit(mainloop_handle);
+    return FALSE;
+}
+
+static void RUNNING(background_activity_t *activity, void *user_data)
+{
+    /* Suspend is blocked before entry to this function.
+     *
+     * In order for it not to stay blocked forever, ALL
+     * EXECTION PATHS THAT CAN BE TAKEN FROM HERE MUST
+     * END UP CALLING EITHER background_activity_wait()
+     * OR background_activity_stop().
+     */
+    static int count = 0;
+
+    printf("%s(%s) #%d\n", __FUNCTION__, (char *)user_data, ++count);
+
+    if( count < 3 ) {
+        /* After delay make background_activity_wait() call */
+        g_timeout_add_seconds(10, continue_cb, activity);
+    }
+    else {
+        /* After delay make background_activity_stop() call */
+        g_timeout_add_seconds(10, stop_cb, activity);
+    }
+
+}
+
+static void WAITING(background_activity_t *activity, void *user_data)
+{
+    /* Not needed, just illustrates when state transitions take place */
+    printf("%s(%s)\n", __FUNCTION__, (char *)user_data);
+}
+
+static void STOPPED(background_activity_t *activity, void *user_data)
+{
+    /* Not needed, just illustrates when state transitions take place */
+    printf("%s(%s)\n", __FUNCTION__, (char *)user_data);
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc, (void)argv;
+
+    background_activity_t *activity = 0;
+
+    mainloop_handle = g_main_loop_new(0, 0);
+
+    connect_to_system_bus();
+
+    /* Create background activity object */
+    activity = background_activity_new();
+
+    /* Use dynamically allocated string as user data. It will be
+     * released when background activity object is destroyed. */
+    background_activity_set_user_data(activity, strdup("hello"), free);
+
+    /* Setting up waiting and stopped callbacks is optional, but
+     * can be helpful for example while debugging something */
+    background_activity_set_waiting_callback(activity, WAITING);
+    background_activity_set_stopped_callback(activity, STOPPED);
+
+    /* Running callback must be set up or background activity
+     * object will automatically move to stopped state immediately
+     * after reaching running state  */
+    background_activity_set_running_callback(activity, RUNNING);
+
+    /* Schedule wakeups to occur on 30 second global wakeup slots */
+    background_activity_frequency_t slot =
+        BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_SECONDS;
+    background_activity_set_wakeup_slot(activity, slot);
+
+    /* Start waiting for iphb wakeup */
+    background_activity_wait(activity);
+
+    /* Run mainloop; the 1st timer callback invocation can happen
+     * in 0 to 30 seconds, but the subsequent ones 30 seconds from
+     * the previous one. */
+
+    printf("ENTER MAINLOOP\n");
+    g_main_loop_run(mainloop_handle);
+    printf("LEAVE MAINLOOP\n");
+
+    /* Release background activity object */
+    background_activity_unref(activity);
+
+    disconnect_from_systembus();
+
+    g_main_loop_unref(mainloop_handle);
+    return 0;
+}

--- a/examples-glib/simple-timer-wakeup.c
+++ b/examples-glib/simple-timer-wakeup.c
@@ -1,0 +1,106 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <glib.h>
+#include <dbus/dbus.h>
+#include <dbus/dbus-glib-lowlevel.h>
+#include <keepalive-glib/keepalive-timeout.h>
+
+#include <assert.h>
+
+#define failure(FMT, ARGS...) do {\
+    fprintf(stderr, "%s: "FMT"\n", __FUNCTION__, ## ARGS);\
+    exit(EXIT_FAILURE); \
+} while(0)
+
+static DBusConnection *system_bus = 0;
+static GMainLoop *mainloop_handle = 0;
+
+static void disconnect_from_systembus(void)
+{
+    if( system_bus )
+        dbus_connection_unref(system_bus), system_bus = 0;
+}
+
+static void connect_to_system_bus(void)
+{
+    DBusError err = DBUS_ERROR_INIT;
+    system_bus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+    if( !system_bus )
+        failure("%s: %s", err.name, err.message);
+    dbus_connection_setup_with_g_main(system_bus, 0);
+    dbus_error_free(&err);
+}
+
+static gboolean exit_timer_cb(gpointer aptr)
+{
+    /* Suspend is blocked before this function is called */
+
+    static int count = 0;
+
+    fprintf(stdout, "TIMER %d\n", ++count);
+
+    if( count < 4 ) {
+        /* After returning TRUE the next iphb wakeup is
+         * scheduled and suspending is allowed again */
+        return TRUE;
+    }
+
+    g_main_loop_quit(mainloop_handle);
+
+    /* After returning FALSE all timer resources are
+     * released and suspending is allowed again */
+    return FALSE;
+}
+
+int main(int argc, char **argv)
+{
+    (void)argc, (void)argv;
+
+    mainloop_handle = g_main_loop_new(0, 0);
+
+    connect_to_system_bus();
+
+    /* Create timer that can wake the device from suspend */
+    guint id = keepalive_timeout_add_seconds(15, exit_timer_cb, 0);
+    printf("timer id = %u\n", id);
+
+    /* If needed, the timer can be cancelled similarly to normal
+     * glib timeouts, via: g_source_remove(id) */
+
+    /* Run mainloop; suspend is allowed, except when the
+     * exit_timer_cb is being executed */
+    printf("ENTER MAINLOOP\n");
+    g_main_loop_run(mainloop_handle);
+    printf("LEAVE MAINLOOP\n");
+
+    disconnect_from_systembus();
+
+    g_main_loop_unref(mainloop_handle);
+    return 0;
+}

--- a/lib-glib/.depend
+++ b/lib-glib/.depend
@@ -1,0 +1,78 @@
+keepalive-backgroundactivity.o:\
+	keepalive-backgroundactivity.c\
+	keepalive-backgroundactivity.h\
+	keepalive-cpukeepalive.h\
+	keepalive-heartbeat.h\
+	logging.h\
+
+keepalive-backgroundactivity.pic.o:\
+	keepalive-backgroundactivity.c\
+	keepalive-backgroundactivity.h\
+	keepalive-cpukeepalive.h\
+	keepalive-heartbeat.h\
+	logging.h\
+
+keepalive-cpukeepalive.o:\
+	keepalive-cpukeepalive.c\
+	keepalive-cpukeepalive.h\
+	logging.h\
+	xdbus.h\
+
+keepalive-cpukeepalive.pic.o:\
+	keepalive-cpukeepalive.c\
+	keepalive-cpukeepalive.h\
+	logging.h\
+	xdbus.h\
+
+keepalive-displaykeepalive.o:\
+	keepalive-displaykeepalive.c\
+	keepalive-displaykeepalive.h\
+	logging.h\
+	xdbus.h\
+
+keepalive-displaykeepalive.pic.o:\
+	keepalive-displaykeepalive.c\
+	keepalive-displaykeepalive.h\
+	logging.h\
+	xdbus.h\
+
+keepalive-heartbeat.o:\
+	keepalive-heartbeat.c\
+	keepalive-heartbeat.h\
+	logging.h\
+
+keepalive-heartbeat.pic.o:\
+	keepalive-heartbeat.c\
+	keepalive-heartbeat.h\
+	logging.h\
+
+keepalive-timeout.o:\
+	keepalive-timeout.c\
+	keepalive-backgroundactivity.h\
+	keepalive-timeout.h\
+	logging.h\
+
+keepalive-timeout.pic.o:\
+	keepalive-timeout.c\
+	keepalive-backgroundactivity.h\
+	keepalive-timeout.h\
+	logging.h\
+
+logging.o:\
+	logging.c\
+	logging.h\
+
+logging.pic.o:\
+	logging.c\
+	logging.h\
+
+xdbus.o:\
+	xdbus.c\
+	logging.h\
+	xdbus.h\
+
+xdbus.pic.o:\
+	xdbus.c\
+	logging.h\
+	xdbus.h\
+

--- a/lib-glib/Makefile
+++ b/lib-glib/Makefile
@@ -1,0 +1,210 @@
+# ----------------------------------------------------------- -*- mode: sh -*-
+# List of targets to build
+# ----------------------------------------------------------------------------
+
+NAME     ?= libkeepalive-glib
+ROOT     ?= /tmp/test/$(NAME)
+VERS     := $(shell awk '/^Version:/ { print $$2 }' ../rpm/keepalive.spec)
+
+# Note: library versioning != package versioning
+SO_VERS  ?= .so.1.0.0
+SO_NAME  ?= .so.1
+
+TARGETS  += libkeepalive-glib$(SO_VERS)
+TARGETS  += keepalive-glib.pc
+
+# ----------------------------------------------------------------------------
+# Standard install directories
+# ----------------------------------------------------------------------------
+
+_PREFIX         ?= /usr#                         # /usr
+_INCLUDEDIR     ?= $(_PREFIX)/include#           # /usr/include
+_EXEC_PREFIX    ?= $(_PREFIX)#                   # /usr
+_BINDIR         ?= $(_EXEC_PREFIX)/bin#          # /usr/bin
+_SBINDIR        ?= $(_EXEC_PREFIX)/sbin#         # /usr/sbin
+_LIBEXECDIR     ?= $(_EXEC_PREFIX)/libexec#      # /usr/libexec
+_LIBDIR         ?= $(_EXEC_PREFIX)/lib#          # /usr/lib
+_SYSCONFDIR     ?= /etc#                         # /etc
+_DATADIR        ?= $(_PREFIX)/share#             # /usr/share
+_MANDIR         ?= $(_DATADIR)/man#              # /usr/share/man
+_INFODIR        ?= $(_DATADIR)/info#             # /usr/share/info
+_DEFAULTDOCDIR  ?= $(_DATADIR)/doc#              # /usr/share/doc
+_LOCALSTATEDIR  ?= /var#                         # /var
+_UNITDIR        ?= /lib/systemd/system#
+_TESTSDIR       ?= /opt/tests#                   # /opt/tests
+
+# ----------------------------------------------------------------------------
+# Top level targets
+# ----------------------------------------------------------------------------
+
+.PHONY: build install clean distclean mostlyclean
+
+build:: $(TARGETS)
+
+install:: build
+
+clean:: mostlyclean
+	$(RM) $(TARGETS)
+
+distclean:: clean
+
+mostlyclean::
+	$(RM) *.o *~ *.bak
+
+# ----------------------------------------------------------------------------
+# Default flags
+# ----------------------------------------------------------------------------
+
+CPPFLAGS += -D_GNU_SOURCE
+CPPFLAGS += -D_FILE_OFFSET_BITS=64
+
+COMMON   += -Wall
+COMMON   += -Wextra
+COMMON   += -Wmissing-declarations
+COMMON   += -Os
+COMMON   += -g
+
+CFLAGS   += $(COMMON)
+CFLAGS   += -std=c99
+CFLAGS   += -Wstrict-prototypes
+CFLAGS   += -Wmissing-prototypes
+
+CXXFLAGS += $(COMMON)
+
+LDFLAGS  += -g
+
+LDLIBS   += -Wl,--as-needed
+
+# ----------------------------------------------------------------------------
+# Flags from pkg-config
+# ----------------------------------------------------------------------------
+
+PKG_NAMES += glib-2.0
+PKG_NAMES += dbus-1
+PKG_NAMES += dbus-glib-1
+PKG_NAMES += libiphb
+PKG_NAMES += mce
+
+maintenance  = normalize clean distclean mostlyclean
+intersection = $(strip $(foreach w,$1, $(filter $w,$2)))
+ifneq ($(call intersection,$(maintenance),$(MAKECMDGOALS)),)
+PKG_CONFIG   ?= true
+endif
+
+ifneq ($(strip $(PKG_NAMES)),)
+PKG_CONFIG   ?= pkg-config
+PKG_CFLAGS   := $(shell $(PKG_CONFIG) --cflags $(PKG_NAMES))
+PKG_LDLIBS   := $(shell $(PKG_CONFIG) --libs   $(PKG_NAMES))
+PKG_CPPFLAGS := $(filter -D%,$(PKG_CFLAGS)) $(filter -I%,$(PKG_CFLAGS))
+PKG_CFLAGS   := $(filter-out -I%, $(filter-out -D%, $(PKG_CFLAGS)))
+endif
+
+CPPFLAGS += $(PKG_CPPFLAGS)
+CFLAGS   += $(PKG_CFLAGS)
+LDLIBS   += $(PKG_LDLIBS)
+
+# ----------------------------------------------------------------------------
+# Implicit rules
+# ----------------------------------------------------------------------------
+
+%$(SO_VERS) : LDFLAGS += -shared -Wl,-soname,$*$(SO_NAME)
+
+%$(SO_VERS) :
+	$(CC) -o $@ $^ $(LDFLAGS) $(LDLIBS)
+
+%.o : %.c
+	$(CC) -o $@ -c $< $(CPPFLAGS) $(CFLAGS)
+
+%.pic.o : CFLAGS += -fPIC
+%.pic.o : CFLAGS += -fvisibility=hidden
+
+%.pic.o : %.c
+	$(CC) -o $@ -c $< $(CPPFLAGS) $(CFLAGS)
+
+%.q : %.c
+	$(CC) -o $@ -E $^ $(CPPFLAGS)
+
+clean::
+	$(RM) *.q
+
+TEMPLATE_OPS += -e 's:{{PREFIX}}:$(_PREFIX):g'
+TEMPLATE_OPS += -e 's:{{EXEC_PREFIX}}:$(_EXEC_PREFIX):g'
+TEMPLATE_OPS += -e 's:{{INCLUDEDIR}}:$(_INCLUDEDIR):g'
+TEMPLATE_OPS += -e 's:{{LIBDIR}}:$(_LIBDIR):g'
+TEMPLATE_OPS += -e 's:{{VERS}}:$(VERS):g'
+
+% : %.tpl
+	$(RM) $@
+	sed < $< > $@ $(TEMPLATE_OPS)
+	chmod a-w $@
+
+# ----------------------------------------------------------------------------
+# Explicit dependencies
+# ----------------------------------------------------------------------------
+
+# headers that are included in dev package
+LIBRARY_HDR += keepalive.h
+LIBRARY_HDR += keepalive-backgroundactivity.h
+LIBRARY_HDR += keepalive-cpukeepalive.h
+LIBRARY_HDR += keepalive-displaykeepalive.h
+LIBRARY_HDR += keepalive-heartbeat.h
+LIBRARY_HDR += keepalive-timeout.h
+
+# headers that are used only during build time
+PRIVATE_HDR += logging.h
+PRIVATE_HDR += xdbus.h
+
+# sources with exported functionality
+LIBRARY_SRC += keepalive-backgroundactivity.c
+LIBRARY_SRC += keepalive-cpukeepalive.c
+LIBRARY_SRC += keepalive-displaykeepalive.c
+LIBRARY_SRC += keepalive-heartbeat.c
+LIBRARY_SRC += keepalive-timeout.c
+
+# sources with internal functions only
+LIBRARY_SRC += logging.c
+LIBRARY_SRC += xdbus.c
+
+LIBRARY_OBJ := $(patsubst %.c,%.pic.o,$(LIBRARY_SRC))
+
+libkeepalive-glib$(SO_VERS): $(LIBRARY_OBJ)
+
+# ----------------------------------------------------------------------------
+# Installation rules
+# ----------------------------------------------------------------------------
+
+install::
+	install -m755 -d $(ROOT)$(_LIBDIR)/
+	install -m644 libkeepalive-glib$(SO_VERS) $(ROOT)$(_LIBDIR)/
+	ln -sf  libkeepalive-glib$(SO_VERS) $(ROOT)$(_LIBDIR)/libkeepalive-glib.so
+
+	install -m755 -d $(ROOT)$(_INCLUDEDIR)/keepalive-glib/
+	install -m644 $(LIBRARY_HDR) $(ROOT)$(_INCLUDEDIR)/keepalive-glib/
+
+	install -m755 -d $(ROOT)$(_LIBDIR)/pkgconfig/
+	install -m644 keepalive-glib.pc $(ROOT)$(_LIBDIR)/pkgconfig/
+
+# ----------------------------------------------------------------------------
+# Source code normalization
+# ----------------------------------------------------------------------------
+
+.PHONY: normalize
+normalize::
+	normalize_whitespace -M Makefile
+	normalize_whitespace -a $(wildcard *.[ch] *.cc *.cpp *.pc.tpl *.py)
+
+# ----------------------------------------------------------------------------
+# Automatic header dependencies
+# ----------------------------------------------------------------------------
+
+.PHONY: depend
+depend::
+	@echo "Updating .depend"
+	$(CC) -MM $(CPPFLAGS) *.c |\
+	./depend_filter.py > .depend
+
+ifneq ($(MAKECMDGOALS),depend) # not while: make depend
+ifneq (,$(wildcard .depend))   # not if .depend does not exist
+include .depend
+endif
+endif

--- a/lib-glib/Makefile
+++ b/lib-glib/Makefile
@@ -4,7 +4,10 @@
 
 NAME     ?= libkeepalive-glib
 ROOT     ?= /tmp/test/$(NAME)
-VERS     := $(shell awk '/^Version:/ { print $$2 }' ../rpm/keepalive.spec)
+
+# Needed for local builds with make; rpm build will set it via spec file
+VERS     ?= $(shell awk '/^Version:/ { print $$2 }' ../rpm/keepalive.spec)
+VERS     := $(VERS)
 
 # Note: library versioning != package versioning
 SO_VERS  ?= .so.1.0.0

--- a/lib-glib/depend_filter.py
+++ b/lib-glib/depend_filter.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python
+# -*- encoding: utf8 -*-
+
+# ----------------------------------------------------------------------------
+# Copyright (C) 2012 Jolla Ltd.
+# Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+# License: GPLv2
+# ----------------------------------------------------------------------------
+
+import sys,os
+
+def is_local(path):
+    return not path.startswith("/")
+
+def print_rule(dest, srce):
+    print "%s\\\n" % "\\\n\t".join(["%s:" % dest] + srce)
+
+def set_extension(path, ext):
+    return os.path.splitext(path)[0] + ext
+
+def normalize_path(srce):
+    return os.path.normpath(srce)
+
+def fix_directory(dest, srce):
+    srce = os.path.dirname(srce)
+    dest = os.path.basename(dest)
+    return os.path.join(srce, dest)
+
+if __name__ == "__main__":
+
+    data = sys.stdin.readlines()
+    data = map(lambda x:x.rstrip(), data)
+    data.reverse()
+
+    deps = []
+
+    # Note: dependencies are sorted only to keep
+    #       future diffs cleaner
+
+    while data:
+        line = data.pop()
+        while line.endswith('\\'):
+            line = line[:-1] + data.pop()
+        if not ':' in line:
+            continue
+
+        dest,srce = line.split(":",1)
+        srce = srce.split()
+        srce,temp = srce[0],srce[1:]
+
+        # take dest path primary srce
+        dest = fix_directory(dest, srce)
+
+        # remove secondary deps with absolute path
+        temp = filter(is_local, temp)
+
+        # sort secondary sources
+        temp.sort()
+
+        srce = [srce] + temp
+        srce = map(normalize_path, srce)
+
+        deps.append((dest,srce))
+
+    for dest,srce in sorted(deps):
+        # emit normal compilation dependencies
+        print_rule(dest, srce)
+        # and for -fPIC in case it is needed
+        dest = set_extension(dest, ".pic.o")
+        print_rule(dest, srce)

--- a/lib-glib/depend_filter.py
+++ b/lib-glib/depend_filter.py
@@ -1,11 +1,31 @@
 #!/usr/bin/env python
 # -*- encoding: utf8 -*-
 
-# ----------------------------------------------------------------------------
-# Copyright (C) 2012 Jolla Ltd.
+#######################################################################################
+#
+# Copyright (C) 2012-2014 Jolla Ltd.
 # Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
-# License: GPLv2
-# ----------------------------------------------------------------------------
+# All rights reserved.
+#
+# This file is part of nemo keepalive package.
+#
+# You may use this file under the terms of the GNU Lesser General
+# Public License version 2.1 as published by the Free Software Foundation
+# and appearing in the file license.lgpl included in the packaging
+# of this file.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License version 2.1 as published by the Free Software Foundation
+# and appearing in the file license.lgpl included in the packaging
+# of this file.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# Lesser General Public License for more details.
+#
+#######################################################################################
 
 import sys,os
 

--- a/lib-glib/keepalive-backgroundactivity.c
+++ b/lib-glib/keepalive-backgroundactivity.c
@@ -1,0 +1,644 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "keepalive-backgroundactivity.h"
+#include "keepalive-heartbeat.h"
+#include "keepalive-cpukeepalive.h"
+
+#include "logging.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+/* Logging prefix for this module */
+#define PFIX "background activity"
+
+/** Memory tag for marking live background_activity_t objects */
+#define BACKGROUND_ACTIVITY_MAJICK_ALIVE 0x54913336
+
+/** Memory tag for marking dead background_activity_t objects */
+#define BACKGROUND_ACTIVITY_MAJICK_DEAD  0x00000000
+
+/* ========================================================================= *
+ * TYPES
+ * ========================================================================= */
+
+/** Enumeration of states background activity object can be in */
+typedef enum
+{
+    /** Neither waiting for heartbeat wakeup nor blocking suspend */
+    BACKGROUND_ACTIVITY_STATE_STOPPED = 0,
+
+    /** Waiting for heartbeat wakeup */
+    BACKGROUND_ACTIVITY_STATE_WAITING = 1,
+
+    /** Blocking suspend */
+    BACKGROUND_ACTIVITY_STATE_RUNNING = 2,
+
+} background_activity_state_t;
+
+static const char *
+background_activity_state_repr(background_activity_state_t state)
+{
+    const char *res = "UNKNOWN";
+    switch( state ) {
+    case BACKGROUND_ACTIVITY_STATE_STOPPED: res = "STOPPED"; break;
+    case BACKGROUND_ACTIVITY_STATE_WAITING: res = "WAITING"; break;
+    case BACKGROUND_ACTIVITY_STATE_RUNNING: res = "RUNNING"; break;
+    default: break;
+    }
+    return res;
+}
+
+/** Wakeup delay using either Global slot or range */
+typedef struct
+{
+    /** Global wakeup slot, or BACKGROUND_ACTIVITY_FREQUENCY_RANGE
+     *  in case ranged wakeup is to be used */
+    background_activity_frequency_t wd_slot;
+
+    /** Minimum ranged wait period length */
+    int                             wd_range_lo;
+
+    /** Maximum ranged wait period length */
+    int                             wd_range_hi;
+} wakeup_delay_t;
+
+/** State data for background activity object
+ */
+struct background_activity_t
+{
+    /** Simple memory tag to catch usage of obviously bogus
+     *  background_activity_t pointers */
+    unsigned                        bga_majick;
+
+    /** Reference count; initially 1, released when drops to 0 */
+    unsigned                        bga_ref_count;
+
+    /** Current state: Stopped, Waiting or Running */
+    background_activity_state_t     bga_state;
+
+    /** Requested wakeup slot/range */
+    wakeup_delay_t                  bga_wakeup_curr;
+
+    /** Last wakeup slot/range actually used for iphb ipc
+     *
+     * Used for detecting Waiting -> Waiting transitions
+     * that need to reprogram the wait time */
+    wakeup_delay_t                  bga_wakeup_last;
+
+    /** User data pointer passed to notification callbacks */
+    void                           *bga_user_data;
+
+    /** Callback for freeing bga_user_data */
+    background_activity_free_fn     bga_user_free;
+
+    /** Notify transition to Running state */
+    background_activity_event_fn    bga_running_cb;
+
+    /** Notify transition to Waiting state */
+    background_activity_event_fn    bga_waiting_cb;
+
+    /** Notify transition to Stopped state */
+    background_activity_event_fn    bga_stopped_cb;
+
+    /** For iphb wakeup ipc with dsme */
+    heartbeat_t                    *bga_heartbeat;
+
+    /** For cpu keepalive ipc with mce */
+    cpukeepalive_t                 *bga_keepalive;
+
+    // Update also: background_activity_ctor() & background_activity_dtor()
+};
+
+/* ========================================================================= *
+ * INTERNAL FUNCTION PROTOTYPES
+ * ========================================================================= */
+
+// WAKEUP_DELAY
+
+static void wakeup_delay_set_slot  (wakeup_delay_t *self, background_activity_frequency_t slot);
+static void wakeup_delay_set_range (wakeup_delay_t *self, int range_lo, int range_hi);
+static bool wakeup_delay_eq_p      (const wakeup_delay_t *self, const wakeup_delay_t *that);
+
+// CONSTRUCT_DESTRUCT
+static void background_activity_ctor  (background_activity_t *self);
+static void background_activity_dtor  (background_activity_t *self);
+
+// STATE_TRANSITIONS
+
+static background_activity_state_t background_activity_get_state (const background_activity_t *self);
+static void                        background_activity_set_state (background_activity_t *self, background_activity_state_t state);
+
+// HEARTBEAT_WAKEUP
+
+static void background_activity_heartbeat_wakeup_cb (void *aptr);
+
+/* ========================================================================= *
+ * INTERNAL FUNCTIONS
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * WAKEUP_DELAY
+ * ------------------------------------------------------------------------- */
+
+/** Default initial wakeup delay */
+static const wakeup_delay_t wakeup_delay_default =
+{
+    .wd_slot     = BACKGROUND_ACTIVITY_FREQUENCY_ONE_HOUR,
+    .wd_range_lo = BACKGROUND_ACTIVITY_FREQUENCY_ONE_HOUR,
+    .wd_range_hi = BACKGROUND_ACTIVITY_FREQUENCY_ONE_HOUR,
+};
+
+/** Set wakeup delay to use global wakeup slot
+ *
+ * @param self  wake up delay object
+ * @param slot  global wakeup slot to use
+ */
+static void
+wakeup_delay_set_slot(wakeup_delay_t *self,
+                      background_activity_frequency_t slot)
+{
+    // basically it is just a second count, but it must be
+
+    // a) not smaller than the smallest allowed global slot
+
+    if( slot < BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_SECONDS )
+         slot = BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_SECONDS;
+
+    // b) evenly divisible by the smallest allowed global slot
+
+    slot = slot - (slot % BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_SECONDS);
+
+    self->wd_slot     = slot;
+    self->wd_range_lo = slot;
+    self->wd_range_hi = slot;
+}
+
+/** Set wakeup delay to use wakeup range
+ *
+ * @param self      wake up delay object
+ * @param range_lo  minimum seconds to wait
+ * @param range_hi  maximum seconds to wait
+ */
+static void
+wakeup_delay_set_range(wakeup_delay_t *self,
+                       int range_lo, int range_hi)
+{
+    /* Currently there is no way to tell what kind of hw watchdog
+     * kicking period dsme is using - assume that it is 12 seconds */
+    const int heartbeat_period = 12;
+
+    /* Zero wait is not supported */
+    if( range_lo < 1 )
+         range_lo = 1;
+
+    /* Expand invalid range to heartbeat length */
+    if( range_hi <= range_lo )
+         range_hi = range_lo + heartbeat_period;
+
+    self->wd_slot     = BACKGROUND_ACTIVITY_FREQUENCY_RANGE;
+    self->wd_range_lo = range_lo;
+    self->wd_range_hi = range_hi;
+}
+
+/** Predicate for: two wake up delay objects are the same
+ *
+ * @param self      wake up delay object
+ */
+static bool
+wakeup_delay_eq_p(const wakeup_delay_t *self, const wakeup_delay_t *that)
+{
+    return (self->wd_slot     == that->wd_slot     &&
+            self->wd_range_lo == that->wd_range_lo &&
+            self->wd_range_hi == that->wd_range_hi);
+}
+
+/* ------------------------------------------------------------------------- *
+ * CONSTRUCT_DESTRUCT
+ * ------------------------------------------------------------------------- */
+
+/** Check if background activity pointer is valid
+ *
+ * @param self  background activity object pointer
+ *
+ * @return true if pointer is likely to be valid, false otherwise
+ */
+static bool
+background_activity_is_valid(background_activity_t *self)
+{
+    return self && self->bga_majick == BACKGROUND_ACTIVITY_MAJICK_ALIVE;
+}
+
+/** Construct background activity object
+ *
+ * @param self  pointer to uninitialized background activity object
+ */
+static void
+background_activity_ctor(background_activity_t *self)
+{
+    /* Flag object as valid */
+    self->bga_majick = BACKGROUND_ACTIVITY_MAJICK_ALIVE;
+
+    /* Initial ref count is one */
+    self->bga_ref_count = 1;
+
+    /* In stopped state */
+    self->bga_state = BACKGROUND_ACTIVITY_STATE_STOPPED;
+
+    /* Sane wakeup delay defaults */
+    self->bga_wakeup_curr = wakeup_delay_default;
+    self->bga_wakeup_last = wakeup_delay_default;
+
+    /* No user data */
+    self->bga_user_data = 0;
+    self->bga_user_free = 0;
+
+    /* No notification callbacks */
+    self->bga_running_cb = 0;
+    self->bga_waiting_cb = 0;
+    self->bga_stopped_cb = 0;
+
+    /* Heartbeat object for waking up */
+    self->bga_heartbeat  = heartbeat_new();
+    heartbeat_set_notify(self->bga_heartbeat,
+                         background_activity_heartbeat_wakeup_cb,
+                         self, 0);
+
+    /* Keepalive object for staying up */
+    self->bga_keepalive  = cpukeepalive_new();
+
+    log_debug(PFIX"(%s): created", background_activity_get_id(self));
+}
+
+/** Construct background activity object
+ *
+ * @param self  background activity object pointer
+ */
+static void
+background_activity_dtor(background_activity_t *self)
+{
+    log_debug(PFIX"(%s): deleted", background_activity_get_id(self));
+
+    /* Relase user data */
+    background_activity_free_user_data(self);
+
+    /* Detach heartbeat object */
+    heartbeat_unref(self->bga_heartbeat),
+        self->bga_heartbeat = 0;
+
+    /* Detach keepalive object */
+    cpukeepalive_unref(self->bga_keepalive),
+        self->bga_keepalive = 0;
+
+    /* Flag object as invalid */
+    self->bga_majick = BACKGROUND_ACTIVITY_MAJICK_DEAD;
+}
+
+/* ------------------------------------------------------------------------- *
+ * STATE_TRANSITIONS
+ * ------------------------------------------------------------------------- */
+
+/* Set state of background activity object
+ *
+ * @param self   background activity object pointer
+ * @param state  BACKGROUND_ACTIVITY_STATE_STOPPED|WAITING|RUNNING
+ */
+static void
+background_activity_set_state(background_activity_t *self,
+                              background_activity_state_t state)
+{
+    if( self->bga_state == state ) {
+        if( state != BACKGROUND_ACTIVITY_STATE_WAITING )
+            goto cleanup;
+
+        if( wakeup_delay_eq_p(&self->bga_wakeup_curr,
+                              &self->bga_wakeup_last) )
+            goto cleanup;
+    }
+
+    log_notice(PFIX"(%s): state: %s -> %s",
+               background_activity_get_id(self),
+               background_activity_state_repr(self->bga_state),
+               background_activity_state_repr(state));
+
+    /* leave old state */
+    bool was_running = false;
+
+    switch( self->bga_state ) {
+    case BACKGROUND_ACTIVITY_STATE_STOPPED:
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_WAITING:
+        /* heartbeat timer can be cancelled before state transition */
+        heartbeat_stop(self->bga_heartbeat);
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_RUNNING:
+        /* keepalive timer must be cancelled after state transition */
+        was_running = true;
+        break;
+    }
+
+    /* enter new state */
+    switch( state ) {
+    case BACKGROUND_ACTIVITY_STATE_STOPPED:
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_WAITING:
+        heartbeat_set_delay(self->bga_heartbeat,
+                            self->bga_wakeup_curr.wd_range_lo,
+                            self->bga_wakeup_curr.wd_range_hi);
+
+        self->bga_wakeup_last = self->bga_wakeup_curr;
+
+        heartbeat_start(self->bga_heartbeat);
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_RUNNING:
+        cpukeepalive_start(self->bga_keepalive);
+        break;
+    }
+
+    /* special case: allow heartbeat timer reprogramming
+     * to occur before stopping the keepalive period */
+    if( was_running )
+        cpukeepalive_stop(self->bga_keepalive);
+
+    /* skip notifications if state does not actually change */
+    if( self->bga_state == state )
+        goto cleanup;
+
+    /* NOTE: To minimize hazards no member data modifications are
+     *       allowed after the notification callbacks are called!
+     */
+    switch( (self->bga_state = state) ) {
+    case BACKGROUND_ACTIVITY_STATE_STOPPED:
+        if( self->bga_stopped_cb )
+            self->bga_stopped_cb(self, self->bga_user_data);
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_WAITING:
+        if( self->bga_waiting_cb )
+            self->bga_waiting_cb(self, self->bga_user_data);
+        break;
+
+    case BACKGROUND_ACTIVITY_STATE_RUNNING:
+        if( self->bga_running_cb ) {
+            /* Whatever happens at the callback function, it
+             * MUST end up with a call background_activity_stop()
+             * or background_activity_wait() or the suspend can
+             * be blocked until the process makes an exit */
+            self->bga_running_cb(self, self->bga_user_data);
+        }
+        else {
+            /* Refuse to stay in Running state if notification
+             * callback is not registered */
+            background_activity_stop(self);
+        }
+        break;
+    }
+
+cleanup:
+
+    return;
+}
+
+/** Get state of background activity object
+ *
+ * @param self  background activity object pointer
+ *
+ * @return BACKGROUND_ACTIVITY_STATE_STOPPED|WAITING|RUNNING
+ */
+static background_activity_state_t
+background_activity_get_state(const background_activity_t *self)
+{
+    return self->bga_state;
+}
+
+/* ------------------------------------------------------------------------- *
+ * HEARTBEAT_WAKEUP
+ * ------------------------------------------------------------------------- */
+
+/** Handle heartbeat wakeup
+ *
+ * @param aptr background activity object as void pointer
+ */
+static void
+background_activity_heartbeat_wakeup_cb(void *aptr)
+{
+    background_activity_t *self = aptr;
+
+    log_notice(PFIX"(%s): iphb wakeup", background_activity_get_id(self));
+
+    if( background_activity_is_waiting(self) )
+        background_activity_run(self);
+}
+
+/* ========================================================================= *
+ * EXTERNAL API  --  documented in: keepalive-backgroundactivity.h
+ * ========================================================================= */
+
+background_activity_t *
+background_activity_new(void)
+{
+    log_enter_function();
+
+    background_activity_t *self = calloc(1, sizeof *self);
+
+    if( self )
+        background_activity_ctor(self);
+
+    return self;
+}
+
+background_activity_t *
+background_activity_ref(background_activity_t *self)
+{
+    log_enter_function();
+
+    background_activity_t *ref = 0;
+
+    if( !background_activity_is_valid(self) )
+        goto cleanup;
+
+    ++self->bga_ref_count;
+
+    ref = self;
+
+cleanup:
+    return ref;
+}
+
+void
+background_activity_unref(background_activity_t *self)
+{
+    log_enter_function();
+
+    if( !background_activity_is_valid(self) )
+        goto cleanup;
+
+    if( --self->bga_ref_count != 0 )
+         goto cleanup;
+
+    background_activity_dtor(self);
+    free(self);
+
+cleanup:
+    return;
+}
+
+background_activity_frequency_t
+background_activity_get_wakeup_slot(const background_activity_t *self)
+{
+    return self->bga_wakeup_curr.wd_slot;
+}
+
+void
+background_activity_set_wakeup_slot(background_activity_t *self,
+                                    background_activity_frequency_t slot)
+{
+    wakeup_delay_set_slot(&self->bga_wakeup_curr, slot);
+}
+
+void
+background_activity_get_wakeup_range(const background_activity_t *self,
+                                     int *range_lo, int *range_hi)
+{
+    *range_lo = self->bga_wakeup_curr.wd_range_lo;
+    *range_hi = self->bga_wakeup_curr.wd_range_hi;
+}
+
+void
+background_activity_set_wakeup_range(background_activity_t *self,
+                                     int range_lo, int range_hi)
+{
+    wakeup_delay_set_range(&self->bga_wakeup_curr, range_lo, range_hi);
+}
+
+bool
+background_activity_is_waiting(const background_activity_t *self)
+{
+    return background_activity_get_state(self) == BACKGROUND_ACTIVITY_STATE_WAITING;
+}
+
+bool
+background_activity_is_running(const background_activity_t *self)
+{
+    return background_activity_get_state(self) == BACKGROUND_ACTIVITY_STATE_RUNNING;
+}
+
+bool
+background_activity_is_stopped(const background_activity_t *self)
+{
+    return background_activity_get_state(self) == BACKGROUND_ACTIVITY_STATE_RUNNING;
+}
+
+void background_activity_wait(background_activity_t *self)
+{
+    background_activity_set_state(self, BACKGROUND_ACTIVITY_STATE_WAITING);
+}
+
+void background_activity_run(background_activity_t *self)
+{
+    background_activity_set_state(self, BACKGROUND_ACTIVITY_STATE_RUNNING);
+}
+
+void background_activity_stop(background_activity_t *self)
+{
+    background_activity_set_state(self, BACKGROUND_ACTIVITY_STATE_STOPPED);
+}
+
+const char *
+background_activity_get_id(const background_activity_t *self)
+{
+    return cpukeepalive_get_id(self->bga_keepalive);
+}
+
+void
+background_activity_free_user_data(background_activity_t *self)
+{
+    if( self->bga_user_data && self->bga_user_free )
+         self->bga_user_free(self->bga_user_data);
+
+    self->bga_user_data = 0;
+    self->bga_user_free = 0;
+
+}
+
+void *
+background_activity_get_user_data(const background_activity_t *self)
+{
+    return self->bga_user_data;
+}
+
+void *
+background_activity_steal_user_data(background_activity_t *self)
+{
+    void *user_data = self->bga_user_data;
+
+    self->bga_user_data = 0;
+    self->bga_user_free = 0;
+
+    return user_data;
+}
+
+void
+background_activity_set_user_data(background_activity_t *self,
+                                  void *user_data,
+                                  background_activity_free_fn free_cb)
+{
+    background_activity_free_user_data(self);
+
+    self->bga_user_data = user_data;
+    self->bga_user_free = free_cb;
+}
+
+void
+background_activity_set_running_callback(background_activity_t *self,
+                                         background_activity_event_fn cb)
+{
+    self->bga_running_cb = cb;
+}
+
+void
+background_activity_set_waiting_callback(background_activity_t *self,
+                                         background_activity_event_fn cb)
+{
+    self->bga_waiting_cb = cb;
+}
+
+void
+background_activity_set_stopped_callback(background_activity_t *self,
+                                         background_activity_event_fn cb)
+{
+    self->bga_stopped_cb = cb;
+}

--- a/lib-glib/keepalive-backgroundactivity.h
+++ b/lib-glib/keepalive-backgroundactivity.h
@@ -93,11 +93,13 @@ typedef enum
  *
  * Will be automatically released after reference count drops to zero.
  *
- * @return pointer to background activity object
+ * @return pointer to background activity object, or NULL
  */
 background_activity_t *background_activity_new(void);
 
 /** Increment reference count of background activity object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * @param self  background activity object pointer
  *
@@ -106,6 +108,8 @@ background_activity_t *background_activity_new(void);
 background_activity_t *background_activity_ref(background_activity_t *self);
 
 /** Decrement reference count of background activity object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * The object will be released if reference count reaches zero.
  *

--- a/lib-glib/keepalive-backgroundactivity.h
+++ b/lib-glib/keepalive-backgroundactivity.h
@@ -1,0 +1,345 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_BACKGROUNDACTIVITY_H_
+# define KEEPALIVE_GLIB_BACKGROUNDACTIVITY_H_
+
+# include <stdbool.h>
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# pragma GCC visibility push(default)
+
+/** Opaque background activity object
+ *
+ * Allocate via background_activity_new() and
+ * release via background_activity_unref().
+ */
+typedef struct background_activity_t background_activity_t;
+
+/** Background activity notification function type
+ *
+ * @param aptr  user_data set via background_activity_set_user_data()
+ */
+typedef void (*background_activity_event_fn)(background_activity_t *,
+                                             void *);
+
+/** User data free function type
+ *
+ * Called when background activity object is deleted after the
+ * final reference is dropped via background_activity_unref(), or
+ * when background_activity_set_user_data() is called while user_data
+ * is already set.
+ *
+ * @param user_data  as set via background_activity_set_notify()
+ */
+typedef void (*background_activity_free_fn)(void *);
+
+/** Enumeration of global wakeup slots for background activity objects */
+typedef enum
+{                                                                    // ORIGIN:
+    BACKGROUND_ACTIVITY_FREQUENCY_RANGE                =            0, // Nemomobile
+    BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_SECONDS       =           30, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_TWO_AND_HALF_MINUTES =  30 + 2 * 60, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_FIVE_MINUTES         =       5 * 60, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_TEN_MINUTES          =      10 * 60, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_FIFTEEN_MINUTES      =      15 * 60, // Android
+    BACKGROUND_ACTIVITY_FREQUENCY_THIRTY_MINUTES       =      30 * 60, // Meego & Android
+    BACKGROUND_ACTIVITY_FREQUENCY_ONE_HOUR             =  1 * 60 * 60, // Meego & Android
+    BACKGROUND_ACTIVITY_FREQUENCY_TWO_HOURS            =  2 * 60 * 60, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_FOUR_HOURS           =  4 * 60 * 60, // Nemomobile
+    BACKGROUND_ACTIVITY_FREQUENCY_EIGHT_HOURS          =  8 * 60 * 60, // Nemomobile
+    BACKGROUND_ACTIVITY_FREQUENCY_TEN_HOURS            = 10 * 60 * 60, // Meego
+    BACKGROUND_ACTIVITY_FREQUENCY_TWELVE_HOURS         = 12 * 60 * 60, // Android
+    BACKGROUND_ACTIVITY_FREQUENCY_TWENTY_FOUR_HOURS    = 24 * 60 * 60, // Android
+
+    BACKGROUND_ACTIVITY_FREQUENCY_MAXIMUM_FREQUENCY    =   0x7fffffff, // due to 32-bit libiphb ranges
+
+} background_activity_frequency_t;
+
+/** Create background activity object
+ *
+ * Initially has reference count of 1.
+ *
+ * Use background_activity_ref() to increment reference count and
+ * background_activity_unref() to decrement reference count.
+ *
+ * Will be automatically released after reference count drops to zero.
+ *
+ * @return pointer to background activity object
+ */
+background_activity_t *background_activity_new(void);
+
+/** Increment reference count of background activity object
+ *
+ * @param self  background activity object pointer
+ *
+ * @return pointer to background activity object, or NULL in case of errors
+ */
+background_activity_t *background_activity_ref(background_activity_t *self);
+
+/** Decrement reference count of background activity object
+ *
+ * The object will be released if reference count reaches zero.
+ *
+ * @param self  background activity object pointer
+ */
+void background_activity_unref(background_activity_t *self);
+
+/** Set global wakeup slot for background activity object
+ *
+ * Global wakeup slot is defined as the next time in the future when
+ * some monotonic clock source has full seconds that is multiple of
+ * the given amount of seconds.
+ *
+ * So every process that is using 10 minute slot is woken up
+ * simultaneously. And processes that are using 5 minute slots
+ * wake up simultaneously with the 10 minute wakeups and once
+ * in between the 10 minute slots.
+ *
+ * Note that the 1st wakeup can occur anything from zero to
+ * specified amount of time.
+ *
+ *
+ * SLOT |0.........1.........2.........3.........4.........5
+ *      |012345678901234567890123456789012345678901234567890 -> time
+ *      |
+ *   2  |  x x x x x x x x x x x x x x x x x x x x x x x x x
+ *   5  |     x    x    x    x    x    x    x    x    x    x
+ *  10  |          x         x         x         x         x
+ *
+ * @param self  background activity object pointer
+ * @param slot  seconds
+ */
+void background_activity_set_wakeup_slot(background_activity_t *self,
+                                         background_activity_frequency_t slot);
+
+/** Get global wakeup slot used by background activity object
+ *
+ * @param self  background activity object pointer
+ *
+ * @return seconds, or BACKGROUND_ACTIVITY_FREQUENCY_RANGE if
+ *  ranged wakeup rather than global wakeup slot is used.
+ */
+background_activity_frequency_t background_activity_get_wakeup_slot(const background_activity_t *self);
+
+/** Set wakeup range for background activity object
+ *
+ * The iphb daemon (or dsme iphb plugin nowadays) tries to minimize
+ * the amount of wakeups by maximizing the amount of processes that
+ * are woken up simultaneously.
+ *
+ * For this purpose the wakeup range should be as wide as logically
+ * makes sense for the requesting client, but note that server side
+ * logic does not necessarily take the values as is. If range_lo is
+ * really small compared to range_hi, it will be scaled up to avoid
+ * seemingly premature wake ups.
+ *
+ * As a rule of the thumb range_lo should be >= range_hi * 75% and
+ * range_hi - range_lo >= heartbeat delay (= hw watchdog kick period,
+ * for historical reasons 12 seconds).
+ *
+ * If negative range_hi is used, wakeup range is adjusted to have
+ * the same length as heartbeat delay.
+ *
+ * @param self      background activity object pointer
+ * @param range_lo  minimum sleep time in seconds
+ * @param range_hi  maximum sleep time in seconds, or -1
+ */
+void background_activity_set_wakeup_range(background_activity_t *self, int range_lo, int range_hi);
+
+/** Get wakeup range used by background activity object
+ *
+ * If global wakeup slot is used, the same value is returned for
+ * both range_lo and range_hi.
+ *
+ * @param self      background activity object pointer
+ * @param range_lo  [output] minimum sleep time in seconds
+ * @param range_hi  [output] maximum sleep time in seconds
+ */
+void background_activity_get_wakeup_range(const background_activity_t *self,
+                                          int *range_lo, int *range_hi);
+
+/** Check if background activity object is in stopped state
+ *
+ * Stopped state means the object is not waiting for iphb
+ * wakeup to occur and is not blocking device from suspending.
+ *
+ * @param self  background activity object pointer
+ *
+ * @return true if object is in stopped state, false otherwise
+ */
+bool background_activity_is_stopped(const background_activity_t *self);
+
+/** Check if background activity object is in waiting state
+ *
+ * Waiting state means the object is waiting for iphb wakeup
+ * to occur.
+ *
+ * @param self  background activity object pointer
+ *
+ * @return true if object is in waiting state, false otherwise
+ */
+bool background_activity_is_waiting(const background_activity_t *self);
+
+/** Check if background activity object is in running state
+ *
+ * Waiting state means the object is blocking the device from
+ * entering suspend.
+ *
+ * @param self  background activity object pointer
+ *
+ * @return true if object is in running state, false otherwise
+ */
+bool background_activity_is_running(const background_activity_t *self);
+
+/** Set background activity object to waiting state
+ *
+ * IPHB wakeup slot or range is programmed. Automatic transition
+ * to running state is made when wakeup occurs.
+ *
+ * @param self  background activity object pointer
+ */
+void background_activity_wait(background_activity_t *self);
+
+/** Set background activity object to running state
+ *
+ * CPU-keepalive session is started and device is blocked from
+ * suspending. Application code MUST terminate running state
+ * as soon as possible by calling:
+ *
+ * background_activity_wait() -> schedule next wakeup
+ * background_activity_stop() -> end keepalive session
+ *
+ * @param self  background activity object pointer
+ */
+void background_activity_run(background_activity_t *self);
+
+/** Set background activity object to running state
+ *
+ * Active CPU-keepalive session is stopped / iphb wakeup canceled.
+ *
+ * @param self  background activity object pointer
+ */
+void background_activity_stop(background_activity_t *self);
+
+/** Get client id used for cpu keepalive dbus ipc
+ *
+ * Every cpu-keepalive session needs to have unique within process
+ * id string. This function returns the id string associated with
+ * the background activity object.
+ *
+ * @param self  background activity object pointer
+ *
+ * @return id string
+ */
+const char *background_activity_get_id(const background_activity_t *self);
+
+/** Set user_data argument to be passed to notification callbacks
+ *
+ * If non-null free_cb is specified, the user_data given is released
+ * by it when a) the background activity object is deleted b) user
+ * data is updated via another background_activity_set_user_data()
+ * call.
+ *
+ * @param self       background activity object pointer
+ * @param user_data  data pointer
+ * @param free_cb    data free callback
+ */
+
+void background_activity_set_user_data(background_activity_t *self,
+                                       void *user_data,
+                                       background_activity_free_fn free_cb);
+
+/** Get user_data argument be passed to notification callbacks
+ *
+ * @param self       background activity object pointer
+ *
+ * @return pointer set via background_activity_set_user_data()
+ */
+void *background_activity_get_user_data(const background_activity_t *self);
+
+/** Clear and free user_data that would be passed to notification callbacks
+ *
+ * @param self       background activity object pointer
+ */
+void background_activity_free_user_data(background_activity_t *self);
+
+/** Clear user_data without freeing it
+ *
+ * @param self       background activity object pointer
+ *
+ * @return pointer previously set via background_activity_set_user_data()
+ */
+void *background_activity_steal_user_data(background_activity_t *self);
+
+/** Set notification function to be called on running state
+ *
+ * When background activity object makes transition to running
+ * state the specified notification function is called.
+ *
+ * NOTE: In order not to block suspend forever, the execution
+ * chain started by the callback function MUST end with call to
+ * either background_activity_wait() or background_activity_stop().
+ *
+ * @param self  background activity object pointer
+ * @param cb    callback function pointer, or NULL
+ */
+void background_activity_set_running_callback(background_activity_t *self,
+                                              background_activity_event_fn cb);
+
+/** Set notification function to be called on waiting state
+ *
+ * When background activity object makes transition to waiting
+ * state the specified notification function is called.
+ *
+ * @param self  background activity object pointer
+ * @param cb    callback function pointer, or NULL
+ */
+void background_activity_set_waiting_callback(background_activity_t *self,
+                                              background_activity_event_fn cb);
+
+/** Set notification function to be called on stopped state
+ *
+ * When background activity object makes transition to stopped
+ * state the specified notification function is called.
+ *
+ * @param self  background activity object pointer
+ * @param cb    callback function pointer, or NULL
+ */
+void background_activity_set_stopped_callback(background_activity_t *self,
+                                              background_activity_event_fn cb);
+# pragma GCC visibility pop
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif // KEEPALIVE_GLIB_BACKGROUNDACTIVITY_H_

--- a/lib-glib/keepalive-backgroundactivity.h
+++ b/lib-glib/keepalive-backgroundactivity.h
@@ -296,7 +296,15 @@ void *background_activity_get_user_data(const background_activity_t *self);
  */
 void background_activity_free_user_data(background_activity_t *self);
 
-/** Clear user_data without freeing it
+/** Detach user_data from background activity object without freeing it
+ *
+ * Normally user data attached to background activity objects is
+ * released when object is deleted or replaced by new user data.
+ * If this is not desirable for some reason, the user data can be
+ * detached from object via background_activity_steal_user_data().
+ *
+ * The caller must release the returned data as appropriate when
+ * it is no longer needed.
  *
  * @param self       background activity object pointer
  *

--- a/lib-glib/keepalive-backgroundactivity.h
+++ b/lib-glib/keepalive-backgroundactivity.h
@@ -46,10 +46,10 @@ typedef struct background_activity_t background_activity_t;
 
 /** Background activity notification function type
  *
- * @param aptr  user_data set via background_activity_set_user_data()
+ * @param activity   background activity object pointer
+ * @param user_data  data pointer set via background_activity_set_user_data()
  */
-typedef void (*background_activity_event_fn)(background_activity_t *,
-                                             void *);
+typedef void (*background_activity_event_fn)(background_activity_t *activity, void *user_data);
 
 /** User data free function type
  *

--- a/lib-glib/keepalive-cpukeepalive.c
+++ b/lib-glib/keepalive-cpukeepalive.c
@@ -1,0 +1,887 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "keepalive-cpukeepalive.h"
+
+#include "xdbus.h"
+#include "logging.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <glib.h>
+#include <dbus/dbus.h>
+
+#include <mce/dbus-names.h>
+#include <mce/mode-names.h>
+
+/** Assumed renew period used while dbus query has not been made yet */
+#define CPU_KEEPALIVE_RENEW_MS (60 * 1000)
+
+/* Logging prefix for this module */
+#define PFIX "cpukeepalive: "
+
+/* ========================================================================= *
+ * GENERIC HELPERS
+ * ========================================================================= */
+
+static inline bool
+eq(const char *a, const char *b)
+{
+    return (a && b) ? !strcmp(a, b) : (a == b);
+}
+
+/* ========================================================================= *
+ * TYPES
+ * ========================================================================= */
+
+/** Enumeration of states a D-Bus service can be in */
+typedef enum {
+    NAMEOWNER_UNKNOWN,
+    NAMEOWNER_STOPPED,
+    NAMEOWNER_RUNNING,
+} nameowner_t;
+
+/** Memory tag for marking live cpukeepalive_t objects */
+#define CPUKEEPALIVE_MAJICK_ALIVE 0x548ec404
+
+/** Memory tag for marking dead cpukeepalive_t objects */
+#define CPUKEEPALIVE_MAJICK_DEAD  0x00000000
+
+/** CPU keepalive state object
+ */
+struct cpukeepalive_t
+{
+    /** Simple memory tag to catch usage of obviously bogus
+     *  cpukeepalive_t pointers */
+    unsigned         cka_majick;
+
+    /** Reference count; initially 1, released when drops to 0 */
+    unsigned         cka_refcount;
+
+    /** Unique identifier string */
+    char            *cka_id;
+
+    /** Flag for: preventing device suspend requested */
+    bool             cka_requested;
+
+    /** Flag for: we've already tried to connect to system bus */
+    bool             cka_connect_attempted;
+
+    /** System bus connection */
+    DBusConnection  *cka_systembus;
+
+    /** Flag for: signal filters installed */
+    bool             cka_filter_added;
+
+    /** Current com.nokia.mce name ownership state */
+    nameowner_t      cka_mce_service;
+
+    /** Async dbus query for initial cka_mce_service value */
+    DBusPendingCall *cka_mce_service_pc;
+
+    /** Timer id for active cpu keepalive session */
+    guint            cka_renew_timer_id;
+
+    /** Renew delay for active cpu keepalive session */
+    guint            cka_renew_period_ms;
+
+    /** Async dbus query for initial cka_mce_service value */
+    DBusPendingCall *cka_renew_period_pc;
+
+    /** Idle callback id for starting/stopping keepalive session */
+    guint            cka_rethink_id;
+
+    // NOTE: cpukeepalive_ctor & cpukeepalive_dtor
+};
+
+/* ========================================================================= *
+ * INTERNAL FUNCTIONS
+ * ========================================================================= */
+
+// CONSTRUCT_DESTRUCT
+static void              cpukeepalive_ctor                          (cpukeepalive_t *self);
+static void              cpukeepalive_dtor                          (cpukeepalive_t *self);
+static bool              cpukeepalive_is_valid                      (const cpukeepalive_t *self);
+
+// RENEW_PERIOD
+static guint             cpukeepalive_renew_period_get              (const cpukeepalive_t *self);
+static void              cpukeepalive_renew_period_set              (cpukeepalive_t *self, int delay_ms);
+static void              cpukeepalive_renew_period_query_reply_cb   (DBusPendingCall *pc, void *aptr);
+static void              cpukeepalive_renew_period_query_start      (cpukeepalive_t *self);
+static void              cpukeepalive_renew_period_query_cancel     (cpukeepalive_t *self);
+
+// KEEPALIVE_SESSION
+static void              cpukeepalive_session_ipc                   (cpukeepalive_t *self, const char *method);
+static gboolean          cpukeepalive_session_cb                    (gpointer aptr);
+static void              cpukeepalive_session_start                 (cpukeepalive_t *self);
+static void              cpukeepalive_session_stop                  (cpukeepalive_t *self);
+static void              cpukeepalive_session_restart               (cpukeepalive_t *self);
+
+// RETHINK_STATE
+static void              cpukeepalive_rethink_now                   (cpukeepalive_t *self);
+
+// MCE_SERVICE_TRACKING
+static nameowner_t       cpukeepalive_mce_owner_get                 (const cpukeepalive_t *self);
+static void              cpukeepalive_mce_owner_set                 (cpukeepalive_t *self, nameowner_t state);
+static void              cpukeepalive_mce_owner_query_reply_cb      (DBusPendingCall *pc, void *aptr);
+static void              cpukeepalive_mce_owner_query_start         (cpukeepalive_t *self);
+static void              cpukeepalive_mce_owner_query_cancel        (cpukeepalive_t *self);
+
+// DBUS_SIGNAL_HANDLING
+static void              cpukeepalive_dbus_nameowner_signal_cb      (cpukeepalive_t *self, DBusMessage *sig);
+
+// DBUS_MESSAGE_FILTERS
+static DBusHandlerResult cpukeepalive_dbus_filter_cb                (DBusConnection *con, DBusMessage *msg, void *aptr);
+static void              cpukeepalive_dbus_filter_install           (cpukeepalive_t *self);
+static void              cpukeepalive_dbus_filter_remove            (cpukeepalive_t *self);
+
+// DBUS_CONNECTION
+static void              cpukeepalive_dbus_connect                  (cpukeepalive_t *self);
+static void              cpukeepalive_dbus_disconnect               (cpukeepalive_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONSTRUCT_DESTRUCT
+ * ------------------------------------------------------------------------- */
+
+static char *cpukeepalive_generate_id(void)
+{
+    static unsigned count = 0;
+    char buf[64];
+    snprintf(buf, sizeof buf, "glib_cpu_keepalive_%u", ++count);
+    return strdup(buf);
+}
+
+/** Constructor for cpukeepalive_t objects
+ */
+static void
+cpukeepalive_ctor(cpukeepalive_t *self)
+{
+    log_enter_function();
+
+    /* Mark as valid */
+    self->cka_majick = CPUKEEPALIVE_MAJICK_ALIVE;
+
+    /* Initialize ref count to one */
+    self->cka_refcount = 1;
+
+    /* Assign unique (within process) id for use with mce dbus ipc */
+    self->cka_id = cpukeepalive_generate_id();
+
+    /* Session neither requested nor running */
+    self->cka_requested = false;
+    self->cka_renew_timer_id = 0;
+
+    /* No system bus connection */
+    self->cka_connect_attempted = false;
+    self->cka_systembus = 0;
+    self->cka_filter_added = false;
+
+    /* MCE availability is not known */
+    self->cka_mce_service = NAMEOWNER_UNKNOWN;
+    self->cka_mce_service_pc = 0;
+
+    /* Renew period is unknown */
+    self->cka_renew_period_ms = 0;
+    self->cka_renew_period_pc = 0;
+
+    /* No pending session rethink scheduled */
+    self->cka_rethink_id = 0;
+
+    /* Connect to systembus */
+    cpukeepalive_dbus_connect(self);
+}
+
+/** Destructor for cpukeepalive_t objects
+ */
+static void
+cpukeepalive_dtor(cpukeepalive_t *self)
+{
+    log_enter_function();
+
+    /* Forced stopping of keepalive session */
+    cpukeepalive_stop(self);
+    cpukeepalive_rethink_now(self);
+
+    /* Disconnecting also cancels pending async method calls */
+    cpukeepalive_dbus_disconnect(self);
+
+    /* Free id string */
+    free(self->cka_id),
+        self->cka_id = 0;
+
+    /* Mark as invalid */
+    self->cka_majick = CPUKEEPALIVE_MAJICK_DEAD;
+}
+
+/** Predicate for: cpukeepalive_t object is valid
+ */
+static bool
+cpukeepalive_is_valid(const cpukeepalive_t *self)
+{
+    return self && self->cka_majick == CPUKEEPALIVE_MAJICK_ALIVE;
+}
+/* ========================================================================= *
+ * RENEW_PERIOD
+ * ========================================================================= */
+
+static guint
+cpukeepalive_renew_period_get(const cpukeepalive_t *self)
+{
+    return self->cka_renew_period_ms ?: CPU_KEEPALIVE_RENEW_MS;
+}
+
+static void
+cpukeepalive_renew_period_set(cpukeepalive_t *self, int delay_ms)
+{
+    cpukeepalive_renew_period_query_cancel(self);
+
+    guint delay_old = cpukeepalive_renew_period_get(self);
+
+    if( delay_ms <= 0 )
+        self->cka_renew_period_ms = CPU_KEEPALIVE_RENEW_MS;
+    else
+        self->cka_renew_period_ms = delay_ms;
+
+    guint delay_new = cpukeepalive_renew_period_get(self);
+
+    log_notice(PFIX"renew period: %d", delay_new);
+
+    if( delay_old != delay_new )
+        cpukeepalive_session_restart(self);
+}
+
+static void
+cpukeepalive_renew_period_query_reply_cb(DBusPendingCall *pc, void *aptr)
+{
+    cpukeepalive_t *self = aptr;
+    DBusMessage    *rsp  = 0;
+    DBusError       err  = DBUS_ERROR_INIT;
+    dbus_int32_t    val  = 0;
+
+    if( self->cka_renew_period_pc != pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->cka_renew_period_pc = 0;
+
+    if( !(rsp = dbus_pending_call_steal_reply(pc)) )
+        goto cleanup;
+
+    if( dbus_set_error_from_message(&err, rsp) ||
+        !dbus_message_get_args(rsp, &err,
+                               DBUS_TYPE_INT32, &val,
+                               DBUS_TYPE_INVALID) ) {
+        log_warning(PFIX"renew period reply: %s: %s", err.name, err.message);
+    }
+
+cleanup:
+
+    /* Default will be used and further queries blocked  if we could
+     * not parse non-zero value from the reply message.*/
+    cpukeepalive_renew_period_set(self, val * 1000);
+
+    if( rsp )
+        dbus_message_unref(rsp);
+
+    dbus_error_free(&err);
+}
+
+static void
+cpukeepalive_renew_period_query_start(cpukeepalive_t *self)
+{
+    if( self->cka_renew_period_ms )
+            goto cleanup;
+
+    if( self->cka_renew_period_pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->cka_renew_period_pc =
+        xdbus_method_call(self->cka_systembus,
+                          MCE_SERVICE,
+                          MCE_REQUEST_PATH,
+                          MCE_REQUEST_IF,
+                          MCE_CPU_KEEPALIVE_PERIOD_REQ,
+                          cpukeepalive_renew_period_query_reply_cb,
+                          self, 0,
+                          DBUS_TYPE_STRING, &self->cka_id,
+                          DBUS_TYPE_INVALID);
+cleanup:
+    return;
+}
+
+static void
+cpukeepalive_renew_period_query_cancel(cpukeepalive_t *self)
+{
+    if( self->cka_renew_period_pc ) {
+        log_enter_function();
+
+        dbus_pending_call_cancel(self->cka_renew_period_pc),
+            self->cka_renew_period_pc = 0;
+    }
+}
+
+/* ========================================================================= *
+ * KEEPALIVE_SESSION
+ * ========================================================================= */
+
+/** Helper for making mce dbus method calls for which we want no reply
+ */
+static void
+cpukeepalive_session_ipc(cpukeepalive_t *self, const char *method)
+{
+    if( xdbus_connection_is_valid(self->cka_systembus) ) {
+        xdbus_simple_call(self->cka_systembus,
+                          MCE_SERVICE,
+                          MCE_REQUEST_PATH,
+                          MCE_REQUEST_IF,
+                          method,
+                          DBUS_TYPE_STRING, &self->cka_id,
+                          DBUS_TYPE_INVALID);
+
+        /* Try to ensure that the method call does not get stuck
+         * to output buffer... */
+        dbus_connection_flush(self->cka_systembus);
+    }
+}
+
+/** Timer callback for renewing cpu keepalive session
+ */
+static gboolean
+cpukeepalive_session_cb(gpointer aptr)
+{
+    gboolean keep_going = FALSE;
+    cpukeepalive_t *self = aptr;
+
+    if( !self->cka_renew_timer_id  )
+        goto cleanup;
+
+    log_enter_function();
+
+    cpukeepalive_session_ipc(self, MCE_CPU_KEEPALIVE_START_REQ);
+    keep_going = TRUE;
+
+cleanup:
+    if( !keep_going && self->cka_renew_timer_id  )
+        self->cka_renew_timer_id  = 0;
+
+    return keep_going;
+}
+
+/** Start cpu keepalive session
+ */
+static void
+cpukeepalive_session_start(cpukeepalive_t *self)
+{
+    if( self->cka_renew_timer_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    cpukeepalive_session_ipc(self, MCE_CPU_KEEPALIVE_START_REQ);
+
+    self->cka_renew_timer_id =
+        g_timeout_add(cpukeepalive_renew_period_get(self),
+                      cpukeepalive_session_cb, self);
+
+cleanup:
+    return;
+}
+
+/** Restart cpu keepalive session after renew delay change
+ */
+static void
+cpukeepalive_session_restart(cpukeepalive_t *self)
+{
+    /* skip if not already running */
+    if( !self->cka_renew_timer_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    cpukeepalive_session_ipc(self, MCE_CPU_KEEPALIVE_START_REQ);
+
+    g_source_remove(self->cka_renew_timer_id);
+
+    self->cka_renew_timer_id =
+        g_timeout_add(cpukeepalive_renew_period_get(self),
+                      cpukeepalive_session_cb, self);
+
+cleanup:
+    return;
+}
+
+/** Stop cpu keepalive session
+ */
+static void
+cpukeepalive_session_stop(cpukeepalive_t *self)
+{
+    if( !self->cka_renew_timer_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    g_source_remove(self->cka_renew_timer_id),
+        self->cka_renew_timer_id = 0;
+
+    cpukeepalive_session_ipc(self, MCE_CPU_KEEPALIVE_STOP_REQ);
+
+cleanup:
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * RETHINK_STATE
+ * ------------------------------------------------------------------------- */
+
+static void
+cpukeepalive_rethink_now(cpukeepalive_t *self)
+{
+    bool need_renew_loop = false;
+
+    /* Preventing cpu suspending is possible when mce is running */
+
+    // TODO: should we block only when it is known that mce is
+    //       not up and running?
+    if( cpukeepalive_mce_owner_get(self) != NAMEOWNER_RUNNING )
+        goto cleanup;
+
+    need_renew_loop = self->cka_requested;
+
+cleanup:
+
+    if( need_renew_loop )
+        cpukeepalive_session_start(self);
+    else
+        cpukeepalive_session_stop(self);
+}
+
+/* ------------------------------------------------------------------------- *
+ * MCE_SERVICE_TRACKING
+ * ------------------------------------------------------------------------- */
+
+static nameowner_t
+cpukeepalive_mce_owner_get(const cpukeepalive_t *self)
+{
+    return self->cka_mce_service;
+}
+
+static void
+cpukeepalive_mce_owner_set(cpukeepalive_t *self, nameowner_t state)
+{
+    cpukeepalive_mce_owner_query_cancel(self);
+
+    if( self->cka_mce_service != state ) {
+        log_notice(PFIX"MCE_SERVICE: %d -> %d",
+                   self->cka_mce_service, state);
+        self->cka_mce_service = state;
+
+        if( self->cka_mce_service == NAMEOWNER_RUNNING )
+            cpukeepalive_renew_period_query_start(self);
+
+        cpukeepalive_rethink_now(self);
+    }
+}
+
+static void
+cpukeepalive_mce_owner_query_reply_cb(DBusPendingCall *pc, void *aptr)
+{
+    cpukeepalive_t *self = aptr;
+    DBusMessage        *rsp  = 0;
+    DBusError           err  = DBUS_ERROR_INIT;
+
+    if( self->cka_mce_service_pc != pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->cka_mce_service_pc = 0;
+
+    if( !(rsp = dbus_pending_call_steal_reply(pc)) )
+        goto cleanup;
+
+    const char *owner = 0;
+
+    if( dbus_set_error_from_message(&err, rsp) ||
+        !dbus_message_get_args(rsp, &err,
+                               DBUS_TYPE_STRING, &owner,
+                               DBUS_TYPE_INVALID) ) {
+        if( strcmp(err.name, DBUS_ERROR_NAME_HAS_NO_OWNER) )
+            log_warning(PFIX"GetNameOwner reply: %s: %s", err.name, err.message);
+    }
+
+    cpukeepalive_mce_owner_set(self,
+                               (owner && *owner) ?
+                               NAMEOWNER_RUNNING : NAMEOWNER_STOPPED);
+
+cleanup:
+
+    if( rsp )
+        dbus_message_unref(rsp);
+
+    dbus_error_free(&err);
+}
+
+static void
+cpukeepalive_mce_owner_query_start(cpukeepalive_t *self)
+{
+    if( self->cka_mce_service_pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    const char *arg = MCE_SERVICE;
+
+    self->cka_mce_service_pc =
+        xdbus_method_call(self->cka_systembus,
+                          DBUS_SERVICE_DBUS,
+                          DBUS_PATH_DBUS,
+                          DBUS_INTERFACE_DBUS,
+                          "GetNameOwner",
+                          cpukeepalive_mce_owner_query_reply_cb,
+                          self, 0,
+                          DBUS_TYPE_STRING, &arg,
+                          DBUS_TYPE_INVALID);
+cleanup:
+    return;
+}
+
+static void
+cpukeepalive_mce_owner_query_cancel(cpukeepalive_t *self)
+{
+    if( self->cka_mce_service_pc ) {
+        log_enter_function();
+
+        dbus_pending_call_cancel(self->cka_mce_service_pc),
+            self->cka_mce_service_pc = 0;
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * DBUS_SIGNAL_HANDLING
+ * ------------------------------------------------------------------------- */
+
+#define DBUS_NAMEOWENERCHANGED_SIG "NameOwnerChanged"
+
+static void
+cpukeepalive_dbus_nameowner_signal_cb(cpukeepalive_t *self, DBusMessage *sig)
+{
+    log_enter_function();
+
+    const char *name = 0;
+    const char *prev = 0;
+    const char *curr = 0;
+
+    DBusError err = DBUS_ERROR_INIT;
+
+    if( !dbus_message_get_args(sig, &err,
+                               DBUS_TYPE_STRING, &name,
+                               DBUS_TYPE_STRING, &prev,
+                               DBUS_TYPE_STRING, &curr,
+                               DBUS_TYPE_INVALID) ) {
+        log_warning(PFIX"can't parse name owner changed signal: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    if( eq(name, MCE_SERVICE) ) {
+        cpukeepalive_mce_owner_set(self,
+                                         *curr ? NAMEOWNER_RUNNING : NAMEOWNER_STOPPED);
+    }
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * DBUS_MESSAGE_FILTERS
+ * ------------------------------------------------------------------------- */
+
+/** D-Bus rule for listening to mce name ownership changes */
+static const char rule_nameowner_mce[] = ""
+"type='signal'"
+",sender='"DBUS_SERVICE_DBUS"'"
+",path='"DBUS_PATH_DBUS"'"
+",interface='"DBUS_INTERFACE_DBUS"'"
+",member='"DBUS_NAMEOWENERCHANGED_SIG"'"
+",arg0='"MCE_SERVICE"'"
+;
+
+/** D-Bus message filter callback for handling signals
+ */
+static DBusHandlerResult
+cpukeepalive_dbus_filter_cb(DBusConnection *con,
+                                DBusMessage *msg,
+                                void *aptr)
+{
+    (void)con;
+
+    log_enter_function();
+
+    DBusHandlerResult result = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+    cpukeepalive_t *self = aptr;
+
+    if( !msg )
+        goto cleanup;
+
+    if( dbus_message_get_type(msg) != DBUS_MESSAGE_TYPE_SIGNAL )
+        goto cleanup;
+
+    const char *interface = dbus_message_get_interface(msg);
+    if( !interface )
+        goto cleanup;
+
+    const char *member = dbus_message_get_member(msg);
+    if( !member )
+        goto cleanup;
+
+    if( !strcmp(interface, DBUS_INTERFACE_DBUS) ) {
+        if( !strcmp(member, DBUS_NAMEOWENERCHANGED_SIG) )
+            cpukeepalive_dbus_nameowner_signal_cb(self, msg);
+    }
+
+cleanup:
+    return result;
+}
+
+/** Start listening to D-Bus signals
+ */
+static void
+cpukeepalive_dbus_filter_install(cpukeepalive_t *self)
+{
+    if( self->cka_filter_added )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->cka_filter_added =
+        dbus_connection_add_filter(self->cka_systembus,
+                                   cpukeepalive_dbus_filter_cb,
+                                   self, 0);
+
+    if( !self->cka_filter_added )
+        goto cleanup;
+
+    if( xdbus_connection_is_valid(self->cka_systembus) ){
+        dbus_bus_add_match(self->cka_systembus, rule_nameowner_mce, 0);
+    }
+
+cleanup:
+    return;
+}
+
+/** Stop listening to D-Bus signals
+ */
+static void
+cpukeepalive_dbus_filter_remove(cpukeepalive_t *self)
+{
+    if( !self->cka_filter_added )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->cka_filter_added = false;
+
+    dbus_connection_remove_filter(self->cka_systembus,
+                                  cpukeepalive_dbus_filter_cb,
+                                  self);
+
+    if( xdbus_connection_is_valid(self->cka_systembus) ){
+        dbus_bus_remove_match(self->cka_systembus, rule_nameowner_mce, 0);
+    }
+
+cleanup:
+    return;
+}
+
+/* ========================================================================= *
+ * DBUS_CONNECTION
+ * ========================================================================= */
+
+/** Connect to D-Bus System Bus
+ */
+static void
+cpukeepalive_dbus_connect(cpukeepalive_t *self)
+{
+    DBusError err = DBUS_ERROR_INIT;
+
+    /* Attempt system bus connect only once */
+    if( self->cka_connect_attempted )
+        goto cleanup;
+
+    self->cka_connect_attempted = true;
+
+    log_enter_function();
+
+    self->cka_systembus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+
+    if( !self->cka_systembus  ) {
+        log_warning(PFIX"can't connect to system bus: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    /* Assumption: The application itself is handling attaching
+     *             the shared systembus connection to mainloop,
+     *             either via dbus_connection_setup_with_g_main()
+     *             or something equivalent. */
+
+    /* Install signal filters */
+    cpukeepalive_dbus_filter_install(self);
+
+    /* Initiate async mce availability query */
+    cpukeepalive_mce_owner_query_start(self);
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+/** Disconnect from D-Bus System Bus
+ */
+static void
+cpukeepalive_dbus_disconnect(cpukeepalive_t *self)
+{
+
+    /* If connection was not made, no need to undo stuff */
+    if( !self->cka_systembus )
+        goto cleanup;
+
+    log_enter_function();
+
+    /* Cancel any pending async method calls */
+    cpukeepalive_mce_owner_query_cancel(self);
+    cpukeepalive_renew_period_query_cancel(self);
+
+    /* Remove signal filters */
+    cpukeepalive_dbus_filter_remove(self);
+
+    /* Detach from system bus */
+    dbus_connection_unref(self->cka_systembus),
+        self->cka_systembus = 0;
+
+    /* Note: As we do not clear cka_connect_attempted flag,
+     *       re-connecting this object is not possible */
+
+cleanup:
+
+    return;
+}
+
+/* ========================================================================= *
+ * EXTERNAL API --  documented in: keepalive-cpukeepalive.h
+ * ========================================================================= */
+
+cpukeepalive_t *
+cpukeepalive_new(void)
+{
+    log_enter_function();
+
+    cpukeepalive_t *self = calloc(1, sizeof *self);
+
+    if( self )
+        cpukeepalive_ctor(self);
+
+    return self;
+}
+
+cpukeepalive_t *
+cpukeepalive_ref(cpukeepalive_t *self)
+{
+    log_enter_function();
+
+    cpukeepalive_t *ref = 0;
+
+    if( !cpukeepalive_is_valid(self) )
+        goto cleanup;
+
+    ++self->cka_refcount;
+
+    ref = self;
+
+cleanup:
+    return ref;
+}
+
+void
+cpukeepalive_unref(cpukeepalive_t *self)
+{
+    log_enter_function();
+
+    if( !cpukeepalive_is_valid(self) )
+        goto cleanup;
+
+    if( --self->cka_refcount != 0 )
+        goto cleanup;
+
+    cpukeepalive_dtor(self);
+    free(self);
+
+cleanup:
+    return;
+}
+
+void
+cpukeepalive_start(cpukeepalive_t *self)
+{
+    if( cpukeepalive_is_valid(self) && !self->cka_requested ) {
+        /* Set we-want-to-prevent-blanking flag */
+        self->cka_requested = true;
+
+        /* Connect to systembus */
+        cpukeepalive_dbus_connect(self);
+
+        /* Check if keepalive session can be started */
+        cpukeepalive_rethink_now(self);
+    }
+}
+
+void
+cpukeepalive_stop(cpukeepalive_t *self)
+{
+    if( cpukeepalive_is_valid(self) && self->cka_requested ) {
+        /* Clear we-want-to-prevent-blanking flag */
+        self->cka_requested = false;
+
+        /* Check if keepalive session needs to be stopped */
+        cpukeepalive_rethink_now(self);
+    }
+}
+
+const char *cpukeepalive_get_id(const cpukeepalive_t *self)
+{
+    return cpukeepalive_is_valid(self) ? self->cka_id : 0;
+}

--- a/lib-glib/keepalive-cpukeepalive.c
+++ b/lib-glib/keepalive-cpukeepalive.c
@@ -857,28 +857,42 @@ cleanup:
 void
 cpukeepalive_start(cpukeepalive_t *self)
 {
-    if( cpukeepalive_is_valid(self) && !self->cka_requested ) {
-        /* Set we-want-to-prevent-blanking flag */
-        self->cka_requested = true;
+    if( !cpukeepalive_is_valid(self) )
+        goto cleanup;
 
-        /* Connect to systembus */
-        cpukeepalive_dbus_connect(self);
+    if( self->cka_requested )
+        goto cleanup;
 
-        /* Check if keepalive session can be started */
-        cpukeepalive_rethink_now(self);
-    }
+    /* Set we-want-to-prevent-blanking flag */
+    self->cka_requested = true;
+
+    /* Connect to systembus */
+    cpukeepalive_dbus_connect(self);
+
+    /* Check if keepalive session can be started */
+    cpukeepalive_rethink_now(self);
+
+cleanup:
+    return;
 }
 
 void
 cpukeepalive_stop(cpukeepalive_t *self)
 {
-    if( cpukeepalive_is_valid(self) && self->cka_requested ) {
-        /* Clear we-want-to-prevent-blanking flag */
-        self->cka_requested = false;
+    if( !cpukeepalive_is_valid(self) )
+        goto cleanup;
 
-        /* Check if keepalive session needs to be stopped */
-        cpukeepalive_rethink_now(self);
-    }
+    if( !self->cka_requested )
+        goto cleanup;
+
+    /* Clear we-want-to-prevent-blanking flag */
+    self->cka_requested = false;
+
+    /* Check if keepalive session needs to be stopped */
+    cpukeepalive_rethink_now(self);
+
+cleanup:
+    return;
 }
 
 const char *cpukeepalive_get_id(const cpukeepalive_t *self)

--- a/lib-glib/keepalive-cpukeepalive.h
+++ b/lib-glib/keepalive-cpukeepalive.h
@@ -51,11 +51,13 @@ typedef struct cpukeepalive_t cpukeepalive_t;
  *
  * Will be automatically released after reference count drops to zero.
  *
- * @return pointer to cpu keepalive object
+ * @return pointer to cpu keepalive object, or NULL
  */
 cpukeepalive_t *cpukeepalive_new(void);
 
 /** Increment reference count of cpu keepalive object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * @param self  cpu keepalive object
  *
@@ -64,6 +66,8 @@ cpukeepalive_t *cpukeepalive_new(void);
 cpukeepalive_t *cpukeepalive_ref(cpukeepalive_t *self);
 
 /** Decrement reference count of cpu keepalive object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * @param self  cpu keepalive object
  *

--- a/lib-glib/keepalive-cpukeepalive.h
+++ b/lib-glib/keepalive-cpukeepalive.h
@@ -1,0 +1,109 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_CPUKEEPALIVE_H_
+# define KEEPALIVE_GLIB_CPUKEEPALIVE_H_
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# pragma GCC visibility push(default)
+
+/** Opaque cpu keepalive structure
+ *
+ * Allocate via cpukeepalive_new() and
+ * release via cpukeepalive_unref().
+ */
+typedef struct cpukeepalive_t cpukeepalive_t;
+
+/** Create cpu keepalive object
+ *
+ * Initially has reference count of 1.
+ *
+ * Use cpukeepalive_ref() to increment reference count and
+ * cpukeepalive_unref() to decrement reference count.
+ *
+ * Will be automatically released after reference count drops to zero.
+ *
+ * @return pointer to cpu keepalive object
+ */
+cpukeepalive_t *cpukeepalive_new(void);
+
+/** Increment reference count of cpu keepalive object
+ *
+ * @param self  cpu keepalive object
+ *
+ * @return pointer to cpu keepalive object, or NULL in case of errors
+ */
+cpukeepalive_t *cpukeepalive_ref(cpukeepalive_t *self);
+
+/** Decrement reference count of cpu keepalive object
+ *
+ * @param self  cpu keepalive object
+ *
+ * The object will be released if reference count reaches zero.
+ */
+void cpukeepalive_unref(cpukeepalive_t *self);
+
+/** Disable normal device suspend policy
+ *
+ * The cpu keepalive object makes the necessary dbus ipc that keeps
+ * the device from suspending while/when the following conditions are met:
+ * 1) mce is running
+ *
+ * @param self  cpu keepalive object
+ */
+void cpukeepalive_start(cpukeepalive_t *self);
+
+/** Enable normal device suspend policy
+ *
+ * @param self  cpu keepalive object
+ */
+void cpukeepalive_stop(cpukeepalive_t *self);
+
+/** Get keepalive id string
+ *
+ * Normally the id string is used to identify cpu keepalive object
+ * when making dbus ipc with mce, but can be also used if application
+ * code needs to have some unique within the process key string to
+ * associate with the cpu keepalive object.
+ *
+ * @param self  cpu keepalive object
+ *
+ * @return id string
+ */
+const char *cpukeepalive_get_id(const cpukeepalive_t *self);
+
+# pragma GCC visibility pop
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif // KEEPALIVE_GLIB_CPUKEEPALIVE_H_

--- a/lib-glib/keepalive-displaykeepalive.c
+++ b/lib-glib/keepalive-displaykeepalive.c
@@ -1,0 +1,1074 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "keepalive-displaykeepalive.h"
+
+#include "xdbus.h"
+#include "logging.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <glib.h>
+#include <dbus/dbus.h>
+
+#include <mce/dbus-names.h>
+#include <mce/mode-names.h>
+
+/** Display keepalive renew time */
+#define DISPLAY_KEEPALIVE_RENEW_MS (60 * 1000)
+
+/* Logging prefix for this module */
+#define PFIX "displaykeepalive: "
+
+/* ========================================================================= *
+ * GENERIC HELPERS
+ * ========================================================================= */
+
+static inline bool
+eq(const char *a, const char *b)
+{
+    return (a && b) ? !strcmp(a, b) : (a == b);
+}
+
+/* ========================================================================= *
+ * TYPES
+ * ========================================================================= */
+
+/** Enumeration of states a D-Bus service can be in */
+typedef enum {
+    NAMEOWNER_UNKNOWN,
+    NAMEOWNER_STOPPED,
+    NAMEOWNER_RUNNING,
+} nameowner_t;
+
+/** Enumeration of states display can be in */
+typedef enum {
+    DISPLAYSTATE_UNKNOWN,
+    DISPLAYSTATE_OFF,
+    DISPLAYSTATE_DIM,
+    DISPLAYSTATE_ON,
+} displaystate_t;
+
+/** Enumeration of states tklock can be in */
+typedef enum
+{
+    TKLOCK_UNKNOWN,
+    TKLOCK_LOCKED,
+    TKLOCK_UNLOCKED,
+} tklockstate_t;
+
+/** Memory tag for marking live displaykeepalive_t objects */
+#define DISPLAYKEEPALIVE_MAJICK_ALIVE 0x548ead10
+
+/** Memory tag for marking dead displaykeepalive_t objects */
+#define DISPLAYKEEPALIVE_MAJICK_DEAD  0x00000000
+
+/** Display keepalive state object
+ */
+struct displaykeepalive_t
+{
+    /** Simple memory tag to catch usage of obviously bogus
+     *  displaykeepalive_t pointers */
+    unsigned         dka_majick;
+
+    /** Reference count; initially 1, released when drops to 0 */
+    unsigned         dka_refcount;
+
+    /** Flag for: preventing display blanking requested */
+    bool             dka_requested;
+
+    /** Flag for: we've already tried to connect to system bus */
+    bool             dka_connect_attempted;
+
+    /** System bus connection */
+    DBusConnection  *dka_systembus;
+
+    /** Flag for: signal filters installed */
+    bool             dka_filter_added;
+
+    /** Current tklock state */
+    tklockstate_t    dka_tklock_state;
+
+    /** Async dbus query for initial dka_tklock_state value */
+    DBusPendingCall *dka_tklock_state_pc;
+
+    /** Current display state */
+    displaystate_t   dka_display_state;
+
+    /** Async dbus query for initial dka_display_state value */
+    DBusPendingCall *dka_display_state_pc;
+
+    /** Current com.nokia.mce name ownership state */
+    nameowner_t      dka_mce_service;
+
+    /** Async dbus query for initial dka_mce_service value */
+    DBusPendingCall *dka_mce_service_pc;
+
+    /** Timer id for active display keepalive session */
+    guint            dka_renew_timer_id;
+
+    /** Idle callback id for starting/stopping keepalive session */
+    guint            dka_rethink_id;
+
+    // NOTE: displaykeepalive_ctor & displaykeepalive_dtor
+};
+
+/* ========================================================================= *
+ * INTERNAL FUNCTIONS
+ * ========================================================================= */
+
+// CONSTRUCT_DESTRUCT
+static void              displaykeepalive_ctor                          (displaykeepalive_t *self);
+static void              displaykeepalive_dtor                          (displaykeepalive_t *self);
+static bool              displaykeepalive_is_valid                      (displaykeepalive_t *self);
+
+// KEEPALIVE_SESSION
+static void              displaykeepalive_session_ipc                   (displaykeepalive_t *self, const char *method);
+static gboolean          displaykeepalive_session_cb                    (gpointer aptr);
+static void              displaykeepalive_session_start                 (displaykeepalive_t *self);
+static void              displaykeepalive_session_stop                  (displaykeepalive_t *self);
+
+// RETHINK_STATE
+static void              displaykeepalive_rethink_now                   (displaykeepalive_t *self);
+static gboolean          displaykeepalive_rethink_idle_cb               (gpointer aptr);
+static void              displaykeepalive_rethink_schedule              (displaykeepalive_t *self);
+static void              displaykeepalive_rethink_cancel                (displaykeepalive_t *self);
+
+// MCE_SERVICE_TRACKING
+static nameowner_t       displaykeepalive_mce_owner_get                 (const displaykeepalive_t *self);
+static void              displaykeepalive_mce_owner_set                 (displaykeepalive_t *self, nameowner_t state);
+static void              displaykeepalive_mce_owner_query_reply_cb      (DBusPendingCall *pc, void *aptr);
+static void              displaykeepalive_mce_owner_query_start         (displaykeepalive_t *self);
+static void              displaykeepalive_mce_owner_query_cancel        (displaykeepalive_t *self);
+
+// TKLOCK_STATE_TRACKING
+static tklockstate_t     displaykeepalive_tklock_get                    (const displaykeepalive_t *self);
+static void              displaykeepalive_tklock_set                    (displaykeepalive_t *self, tklockstate_t state);
+static void              displaykeepalive_tklock_query_reply_cb         (DBusPendingCall *pc, void *aptr);
+static void              displaykeepalive_tklock_query_start            (displaykeepalive_t *self);
+static void              displaykeepalive_tklock_query_cancel           (displaykeepalive_t *self);
+
+// DISPLAY_STATE_TRACKING
+static displaystate_t    displaykeepalive_display_get                   (const displaykeepalive_t *self);
+static void              displaykeepalive_display_set                   (displaykeepalive_t *self, displaystate_t state);
+static void              displaykeepalive_display_query_reply_cb        (DBusPendingCall *pc, void *aptr);
+static void              displaykeepalive_display_query_start           (displaykeepalive_t *self);
+static void              displaykeepalive_display_query_cancel          (displaykeepalive_t *self);
+
+// DBUS_SIGNAL_HANDLING
+static void              displaykeepalive_dbus_tklock_signal_cb         (displaykeepalive_t *self, DBusMessage *sig);
+static void              displaykeepalive_dbus_display_signal_cb        (displaykeepalive_t *self, DBusMessage *sig);
+static void              displaykeepalive_dbus_nameowner_signal_cb      (displaykeepalive_t *self, DBusMessage *sig);
+
+// DBUS_MESSAGE_FILTERS
+static DBusHandlerResult displaykeepalive_dbus_filter_cb                (DBusConnection *con, DBusMessage *msg, void *aptr);
+static void              displaykeepalive_dbus_filter_install           (displaykeepalive_t *self);
+static void              displaykeepalive_dbus_filter_remove            (displaykeepalive_t *self);
+
+// DBUS_CONNECTION
+static void              displaykeepalive_dbus_connect                  (displaykeepalive_t *self);
+static void              displaykeepalive_dbus_disconnect               (displaykeepalive_t *self);
+
+/* ------------------------------------------------------------------------- *
+ * CONSTRUCT_DESTRUCT
+ * ------------------------------------------------------------------------- */
+
+/** Constructor for displaykeepalive_t objects
+ */
+static void
+displaykeepalive_ctor(displaykeepalive_t *self)
+{
+    /* Mark as valid */
+    self->dka_majick = DISPLAYKEEPALIVE_MAJICK_ALIVE;
+
+    /* Initialize ref count to one */
+    self->dka_refcount = 1;
+
+    /* Session neither requested nor running */
+    self->dka_requested = false;
+    self->dka_renew_timer_id = 0;
+
+    /* No system bus connection */
+    self->dka_connect_attempted = false;
+    self->dka_systembus = 0;
+    self->dka_filter_added = false;
+
+    /* Tklock state is not known */
+    self->dka_tklock_state = TKLOCK_UNKNOWN;
+    self->dka_tklock_state_pc = 0;
+
+    /* Display state is not known */
+    self->dka_display_state = DISPLAYSTATE_UNKNOWN;
+    self->dka_display_state_pc = 0;
+
+    /* MCE availability is not known */
+    self->dka_mce_service = NAMEOWNER_UNKNOWN;
+    self->dka_mce_service_pc = 0;
+
+    /* No pending session rethink scheduled */
+    self->dka_rethink_id = 0;
+}
+
+/** Destructor for displaykeepalive_t objects
+ */
+static void
+displaykeepalive_dtor(displaykeepalive_t *self)
+{
+    /* Forced stopping of keepalive session */
+    displaykeepalive_stop(self);
+    displaykeepalive_rethink_now(self);
+
+    /* Disconnecting also cancels pending async method calls */
+    displaykeepalive_dbus_disconnect(self);
+
+    /* Make sure we leave no timers with stale callbacks behind */
+    displaykeepalive_rethink_cancel(self);
+
+    /* Mark as invalid */
+    self->dka_majick = DISPLAYKEEPALIVE_MAJICK_DEAD;
+}
+
+/** Predicate for: displaykeepalive_t object is valid
+ */
+static bool
+displaykeepalive_is_valid(displaykeepalive_t *self)
+{
+    return self && self->dka_majick == DISPLAYKEEPALIVE_MAJICK_ALIVE;
+}
+
+/* ========================================================================= *
+ * KEEPALIVE_SESSION
+ * ========================================================================= */
+
+/** Helper for making mce dbus method calls for which we want no reply
+ */
+static void
+displaykeepalive_session_ipc(displaykeepalive_t *self, const char *method)
+{
+    xdbus_simple_call(self->dka_systembus,
+                      MCE_SERVICE,
+                      MCE_REQUEST_PATH,
+                      MCE_REQUEST_IF,
+                      method,
+                      DBUS_TYPE_INVALID);
+}
+
+/** Timer callback for renewing display keepalive session
+ */
+static gboolean
+displaykeepalive_session_cb(gpointer aptr)
+{
+    gboolean keep_going = FALSE;
+    displaykeepalive_t *self = aptr;
+
+    if( !self->dka_renew_timer_id  )
+        goto cleanup;
+
+    log_enter_function();
+
+    displaykeepalive_session_ipc(self, MCE_PREVENT_BLANK_REQ);
+    keep_going = TRUE;
+
+cleanup:
+    if( !keep_going && self->dka_renew_timer_id  )
+        self->dka_renew_timer_id  = 0;
+
+    return keep_going;
+}
+
+/** Start display keepalive session
+ */
+static void
+displaykeepalive_session_start(displaykeepalive_t *self)
+{
+    if( self->dka_renew_timer_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_renew_timer_id =
+        g_timeout_add(DISPLAY_KEEPALIVE_RENEW_MS,
+                      displaykeepalive_session_cb, self);
+
+    displaykeepalive_session_ipc(self, MCE_PREVENT_BLANK_REQ);
+
+cleanup:
+    return;
+}
+
+/** Stop display keepalive session
+ */
+static void
+displaykeepalive_session_stop(displaykeepalive_t *self)
+{
+    if( !self->dka_renew_timer_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    g_source_remove(self->dka_renew_timer_id),
+        self->dka_renew_timer_id = 0;
+
+    displaykeepalive_session_ipc(self, MCE_CANCEL_PREVENT_BLANK_REQ);
+
+cleanup:
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * RETHINK_STATE
+ * ------------------------------------------------------------------------- */
+
+static void
+displaykeepalive_rethink_now(displaykeepalive_t *self)
+{
+    bool need_renew_loop = false;
+
+    displaykeepalive_rethink_cancel(self);
+
+    /* Preventing display blanking is possible when mce is running,
+     * display is on and lockscreen is not active */
+
+    if( displaykeepalive_mce_owner_get(self) != NAMEOWNER_RUNNING )
+        goto cleanup;
+
+    if( displaykeepalive_display_get(self) != DISPLAYSTATE_ON )
+        goto cleanup;
+
+    if( displaykeepalive_tklock_get(self) != TKLOCK_UNLOCKED )
+        goto cleanup;
+
+    need_renew_loop = self->dka_requested;
+
+cleanup:
+
+    if( need_renew_loop )
+        displaykeepalive_session_start(self);
+    else
+        displaykeepalive_session_stop(self);
+}
+
+static gboolean
+displaykeepalive_rethink_idle_cb(gpointer aptr)
+{
+    displaykeepalive_t *self = aptr;
+
+    if( !self->dka_rethink_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    /* To avoid removing the source id that we're about cancel
+     * via returning FALSE from here, we need to clear the idle
+     * callback id before calling isplaykeepalive_rethink_now() */
+    self->dka_rethink_id = 0;
+
+    displaykeepalive_rethink_now(self);
+
+cleanup:
+    return FALSE;
+}
+
+static void
+displaykeepalive_rethink_schedule(displaykeepalive_t *self)
+{
+    if( !self->dka_rethink_id ) {
+        self->dka_rethink_id =
+            g_idle_add(displaykeepalive_rethink_idle_cb, self);
+    }
+}
+
+static void
+displaykeepalive_rethink_cancel(displaykeepalive_t *self)
+{
+    if( self->dka_rethink_id ) {
+        g_source_remove(self->dka_rethink_id),
+            self->dka_rethink_id = 0;
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * MCE_SERVICE_TRACKING
+ * ------------------------------------------------------------------------- */
+
+static nameowner_t
+displaykeepalive_mce_owner_get(const displaykeepalive_t *self)
+{
+    return self->dka_mce_service;
+}
+
+static void
+displaykeepalive_mce_owner_set(displaykeepalive_t *self,
+                                 nameowner_t state)
+{
+    displaykeepalive_mce_owner_query_cancel(self);
+
+    if( self->dka_mce_service != state ) {
+        log_notice(PFIX"MCE_SERVICE: %d -> %d",
+                   self->dka_mce_service, state);
+        self->dka_mce_service = state;
+
+        if( self->dka_mce_service == NAMEOWNER_RUNNING ) {
+            displaykeepalive_tklock_query_start(self);
+            displaykeepalive_display_query_start(self);
+        }
+        else {
+            displaykeepalive_tklock_set(self, TKLOCK_UNKNOWN);
+            displaykeepalive_display_set(self, DISPLAYSTATE_UNKNOWN);
+        }
+
+        displaykeepalive_rethink_schedule(self);
+    }
+}
+
+static void
+displaykeepalive_mce_owner_query_reply_cb(DBusPendingCall *pc, void *aptr)
+{
+    displaykeepalive_t *self = aptr;
+    DBusMessage        *rsp  = 0;
+    DBusError           err  = DBUS_ERROR_INIT;
+
+    if( self->dka_mce_service_pc != pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_mce_service_pc = 0;
+
+    if( !(rsp = dbus_pending_call_steal_reply(pc)) )
+        goto cleanup;
+
+    const char *owner = 0;
+
+    if( dbus_set_error_from_message(&err, rsp) ||
+        !dbus_message_get_args(rsp, &err,
+                               DBUS_TYPE_STRING, &owner,
+                               DBUS_TYPE_INVALID) ) {
+        if( strcmp(err.name, DBUS_ERROR_NAME_HAS_NO_OWNER) )
+            log_warning(PFIX"GetNameOwner reply: %s: %s", err.name, err.message);
+    }
+
+    displaykeepalive_mce_owner_set(self,
+                                     (owner && *owner) ?
+                                     NAMEOWNER_RUNNING : NAMEOWNER_STOPPED);
+
+cleanup:
+
+    if( rsp )
+        dbus_message_unref(rsp);
+
+    dbus_error_free(&err);
+}
+
+static void
+displaykeepalive_mce_owner_query_start(displaykeepalive_t *self)
+{
+    if( self->dka_mce_service_pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    const char *arg = MCE_SERVICE;
+
+    self->dka_mce_service_pc =
+        xdbus_method_call(self->dka_systembus,
+                          DBUS_SERVICE_DBUS,
+                          DBUS_PATH_DBUS,
+                          DBUS_INTERFACE_DBUS,
+                          "GetNameOwner",
+                          displaykeepalive_mce_owner_query_reply_cb,
+                          self, 0,
+                          DBUS_TYPE_STRING, &arg,
+                          DBUS_TYPE_INVALID);
+cleanup:
+    return;
+}
+
+static void
+displaykeepalive_mce_owner_query_cancel(displaykeepalive_t *self)
+{
+    if( self->dka_mce_service_pc ) {
+        log_enter_function();
+
+        dbus_pending_call_cancel(self->dka_mce_service_pc),
+            self->dka_mce_service_pc = 0;
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * TKLOCK_STATE_TRACKING
+ * ------------------------------------------------------------------------- */
+
+static tklockstate_t
+displaykeepalive_tklock_get(const displaykeepalive_t *self)
+{
+    return self->dka_tklock_state;
+}
+
+static void
+displaykeepalive_tklock_set(displaykeepalive_t *self,
+                             tklockstate_t state)
+{
+    displaykeepalive_tklock_query_cancel(self);
+
+    if( self->dka_tklock_state != state ) {
+        log_notice(PFIX"TKLOCK_STATE: %d -> %d",
+                   self->dka_tklock_state, state);
+        self->dka_tklock_state = state;
+
+        displaykeepalive_rethink_schedule(self);
+    }
+}
+
+static void
+displaykeepalive_tklock_query_reply_cb(DBusPendingCall *pc, void *aptr)
+{
+    displaykeepalive_t *self = aptr;
+
+    DBusMessage *rsp = 0;
+
+    if( self->dka_tklock_state_pc != pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_tklock_state_pc = 0;
+
+    if( !(rsp = dbus_pending_call_steal_reply(pc)) )
+        goto cleanup;
+
+    // reply to query == change signal
+    displaykeepalive_dbus_tklock_signal_cb(self, rsp);
+
+cleanup:
+    if( rsp )
+        dbus_message_unref(rsp);
+}
+
+static void
+displaykeepalive_tklock_query_cancel(displaykeepalive_t *self)
+{
+    if( self->dka_tklock_state_pc ) {
+        log_enter_function();
+
+        dbus_pending_call_cancel(self->dka_tklock_state_pc),
+            self->dka_tklock_state_pc = 0;
+    }
+}
+
+static void
+displaykeepalive_tklock_query_start(displaykeepalive_t *self)
+{
+    if( self->dka_tklock_state_pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_tklock_state_pc =
+        xdbus_method_call(self->dka_systembus,
+                          MCE_SERVICE,
+                          MCE_REQUEST_PATH,
+                          MCE_REQUEST_IF,
+                          MCE_TKLOCK_MODE_GET,
+                          displaykeepalive_tklock_query_reply_cb,
+                          self, 0,
+                          DBUS_TYPE_INVALID);
+cleanup:
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * DISPLAY_STATE_TRACKING
+ * ------------------------------------------------------------------------- */
+
+static displaystate_t
+displaykeepalive_display_get(const displaykeepalive_t *self)
+{
+    return self->dka_display_state;
+}
+
+static void
+displaykeepalive_display_set(displaykeepalive_t *self,
+                             displaystate_t state)
+{
+    displaykeepalive_display_query_cancel(self);
+
+    if( self->dka_display_state != state ) {
+        log_notice(PFIX"DISPLAY_STATE: %d -> %d",
+                   self->dka_display_state, state);
+        self->dka_display_state = state;
+
+        displaykeepalive_rethink_schedule(self);
+    }
+}
+
+static void
+displaykeepalive_display_query_reply_cb(DBusPendingCall *pc, void *aptr)
+{
+    displaykeepalive_t *self = aptr;
+
+    DBusMessage *rsp = 0;
+
+    if( self->dka_display_state_pc != pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_display_state_pc = 0;
+
+    if( !(rsp = dbus_pending_call_steal_reply(pc)) )
+        goto cleanup;
+
+    // reply to query == change signal
+    displaykeepalive_dbus_display_signal_cb(self, rsp);
+
+cleanup:
+    if( rsp )
+        dbus_message_unref(rsp);
+}
+
+static void
+displaykeepalive_display_query_start(displaykeepalive_t *self)
+{
+    if( self->dka_display_state_pc )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_display_state_pc =
+        xdbus_method_call(self->dka_systembus,
+                          MCE_SERVICE,
+                          MCE_REQUEST_PATH,
+                          MCE_REQUEST_IF,
+                          MCE_DISPLAY_STATUS_GET,
+                          displaykeepalive_display_query_reply_cb,
+                          self, 0,
+                          DBUS_TYPE_INVALID);
+cleanup:
+    return;
+}
+
+static void
+displaykeepalive_display_query_cancel(displaykeepalive_t *self)
+{
+    if( self->dka_display_state_pc ) {
+        log_enter_function();
+
+        dbus_pending_call_cancel(self->dka_display_state_pc),
+            self->dka_display_state_pc = 0;
+    }
+}
+
+/* ------------------------------------------------------------------------- *
+ * DBUS_SIGNAL_HANDLING
+ * ------------------------------------------------------------------------- */
+
+#define DBUS_NAMEOWENERCHANGED_SIG "NameOwnerChanged"
+
+static void
+displaykeepalive_dbus_tklock_signal_cb(displaykeepalive_t *self, DBusMessage *sig)
+{
+    log_enter_function();
+
+    const char *state_name = 0;
+
+    DBusError err = DBUS_ERROR_INIT;
+
+    if( !dbus_message_get_args(sig, &err,
+                               DBUS_TYPE_STRING, &state_name,
+                               DBUS_TYPE_INVALID) ) {
+        log_warning(PFIX"can't parse tklock state signal: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    tklockstate_t state = TKLOCK_LOCKED;
+
+    if( eq(state_name, MCE_TK_UNLOCKED) )
+        state = TKLOCK_UNLOCKED;
+
+    displaykeepalive_tklock_set(self, state);
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+static void
+displaykeepalive_dbus_display_signal_cb(displaykeepalive_t *self, DBusMessage *sig)
+{
+    log_enter_function();
+
+    const char *state_name = 0;
+
+    DBusError err = DBUS_ERROR_INIT;
+
+    if( !dbus_message_get_args(sig, &err,
+                               DBUS_TYPE_STRING, &state_name,
+                               DBUS_TYPE_INVALID) ) {
+        log_warning(PFIX"can't parse display state signal: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    displaystate_t state = DISPLAYSTATE_UNKNOWN;
+
+    if( eq(state_name, MCE_DISPLAY_OFF_STRING) )
+        state = DISPLAYSTATE_OFF;
+    else if( eq(state_name, MCE_DISPLAY_DIM_STRING) )
+        state = DISPLAYSTATE_DIM;
+    else if( eq(state_name, MCE_DISPLAY_ON_STRING) )
+        state = DISPLAYSTATE_ON;
+
+    displaykeepalive_display_set(self, state);
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+static void
+displaykeepalive_dbus_nameowner_signal_cb(displaykeepalive_t *self, DBusMessage *sig)
+{
+    log_enter_function();
+
+    const char *name = 0;
+    const char *prev = 0;
+    const char *curr = 0;
+
+    DBusError err = DBUS_ERROR_INIT;
+
+    if( !dbus_message_get_args(sig, &err,
+                               DBUS_TYPE_STRING, &name,
+                               DBUS_TYPE_STRING, &prev,
+                               DBUS_TYPE_STRING, &curr,
+                               DBUS_TYPE_INVALID) ) {
+        log_warning(PFIX"can't parse name owner changed signal: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    if( eq(name, MCE_SERVICE) ) {
+        displaykeepalive_mce_owner_set(self,
+                                         *curr ? NAMEOWNER_RUNNING : NAMEOWNER_STOPPED);
+    }
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * DBUS_MESSAGE_FILTERS
+ * ------------------------------------------------------------------------- */
+
+/** D-Bus rule for listening to mce name ownership changes */
+static const char rule_nameowner_mce[] = ""
+"type='signal'"
+",sender='"DBUS_SERVICE_DBUS"'"
+",path='"DBUS_PATH_DBUS"'"
+",interface='"DBUS_INTERFACE_DBUS"'"
+",member='"DBUS_NAMEOWENERCHANGED_SIG"'"
+",arg0='"MCE_SERVICE"'"
+;
+
+/** D-Bus rule for listening to display state changes */
+static const char rule_display_state[] = ""
+"type='signal'"
+",sender='"MCE_SERVICE"'"
+",path='"MCE_SIGNAL_PATH"'"
+",interface='"MCE_SIGNAL_IF"'"
+",member='"MCE_DISPLAY_SIG"'"
+;
+
+/** D-Bus rule for listening to tklock state changes */
+static const char rule_tklock_state[] = ""
+"type='signal'"
+",sender='"MCE_SERVICE"'"
+",path='"MCE_SIGNAL_PATH"'"
+",interface='"MCE_SIGNAL_IF"'"
+",member='"MCE_TKLOCK_MODE_SIG"'"
+;
+
+/** D-Bus message filter callback for handling signals
+ */
+static DBusHandlerResult
+displaykeepalive_dbus_filter_cb(DBusConnection *con,
+                                DBusMessage *msg,
+                                void *aptr)
+{
+    (void)con;
+
+    DBusHandlerResult result = DBUS_HANDLER_RESULT_NOT_YET_HANDLED;
+    displaykeepalive_t *self = aptr;
+
+    if( !msg )
+        goto cleanup;
+
+    if( dbus_message_get_type(msg) != DBUS_MESSAGE_TYPE_SIGNAL )
+        goto cleanup;
+
+    const char *interface = dbus_message_get_interface(msg);
+    if( !interface )
+        goto cleanup;
+
+    const char *member = dbus_message_get_member(msg);
+    if( !member )
+        goto cleanup;
+
+    if( !strcmp(interface, MCE_SIGNAL_IF) ) {
+        if( !strcmp(member, MCE_DISPLAY_SIG) )
+            displaykeepalive_dbus_display_signal_cb(self, msg);
+        else if( !strcmp(member, MCE_TKLOCK_MODE_SIG) )
+            displaykeepalive_dbus_tklock_signal_cb(self, msg);
+    }
+    else if( !strcmp(interface, DBUS_INTERFACE_DBUS) ) {
+        if( !strcmp(member, DBUS_NAMEOWENERCHANGED_SIG) )
+            displaykeepalive_dbus_nameowner_signal_cb(self, msg);
+    }
+
+cleanup:
+    return result;
+}
+
+/** Start listening to D-Bus signals
+ */
+static void
+displaykeepalive_dbus_filter_install(displaykeepalive_t *self)
+{
+    if( self->dka_filter_added )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_filter_added =
+        dbus_connection_add_filter(self->dka_systembus,
+                                   displaykeepalive_dbus_filter_cb,
+                                   self, 0);
+
+    if( !self->dka_filter_added )
+        goto cleanup;
+
+    if( xdbus_connection_is_valid(self->dka_systembus) ){
+        dbus_bus_add_match(self->dka_systembus, rule_nameowner_mce, 0);
+        dbus_bus_add_match(self->dka_systembus, rule_tklock_state, 0);
+        dbus_bus_add_match(self->dka_systembus, rule_display_state, 0);
+    }
+
+cleanup:
+    return;
+}
+
+/** Stop listening to D-Bus signals
+ */
+static void
+displaykeepalive_dbus_filter_remove(displaykeepalive_t *self)
+{
+    if( !self->dka_filter_added )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_filter_added = false;
+
+    dbus_connection_remove_filter(self->dka_systembus,
+                                  displaykeepalive_dbus_filter_cb,
+                                  self);
+
+    if( xdbus_connection_is_valid(self->dka_systembus) ){
+        dbus_bus_remove_match(self->dka_systembus, rule_nameowner_mce, 0);
+        dbus_bus_remove_match(self->dka_systembus, rule_tklock_state, 0);
+        dbus_bus_remove_match(self->dka_systembus, rule_display_state, 0);
+    }
+
+cleanup:
+    return;
+}
+
+/* ========================================================================= *
+ * DBUS_CONNECTION
+ * ========================================================================= */
+
+/** Connect to D-Bus System Bus
+ */
+static void
+displaykeepalive_dbus_connect(displaykeepalive_t *self)
+{
+    DBusError err = DBUS_ERROR_INIT;
+
+    /* Attempt system bus connect only once */
+    if( self->dka_connect_attempted )
+        goto cleanup;
+
+    log_enter_function();
+
+    self->dka_connect_attempted = true;
+
+    self->dka_systembus = dbus_bus_get(DBUS_BUS_SYSTEM, &err);
+
+    if( !self->dka_systembus  ) {
+        log_warning(PFIX"can't connect to system bus: %s: %s",
+                    err.name, err.message);
+        goto cleanup;
+    }
+
+    /* Assumption: The application itself is handling attaching
+     *             the shared systembus connection to mainloop,
+     *             either via dbus_connection_setup_with_g_main()
+     *             or something equivalent. */
+
+    /* Install signal filters */
+    displaykeepalive_dbus_filter_install(self);
+
+    /* Initiate async mce availability query */
+    displaykeepalive_mce_owner_query_start(self);
+
+cleanup:
+
+    dbus_error_free(&err);
+
+    return;
+}
+
+/** Disconnect from D-Bus System Bus
+ */
+static void
+displaykeepalive_dbus_disconnect(displaykeepalive_t *self)
+{
+    /* If connection was not made, no need to undo stuff */
+    if( !self->dka_systembus )
+        goto cleanup;
+
+    log_enter_function();
+
+    /* Cancel any pending async method calls */
+    displaykeepalive_mce_owner_query_cancel(self);
+    displaykeepalive_display_query_cancel(self);
+    displaykeepalive_tklock_query_cancel(self);
+
+    /* Remove signal filters */
+    displaykeepalive_dbus_filter_remove(self);
+
+    /* Detach from system bus */
+    dbus_connection_unref(self->dka_systembus),
+        self->dka_systembus = 0;
+
+    /* Note: As we do not clear dka_connect_attempted flag,
+     *       re-connecting this object is not possible */
+
+cleanup:
+
+    return;
+}
+
+/* ========================================================================= *
+ * EXTERNAL API --  documented in: keepalive-displaykeepalive.h
+ * ========================================================================= */
+
+displaykeepalive_t *
+displaykeepalive_new(void)
+{
+    log_enter_function();
+
+    displaykeepalive_t *self = calloc(1, sizeof *self);
+
+    if( self )
+        displaykeepalive_ctor(self);
+
+    return self;
+}
+
+displaykeepalive_t *
+displaykeepalive_ref(displaykeepalive_t *self)
+{
+    log_enter_function();
+
+    displaykeepalive_t *ref = 0;
+
+    if( !displaykeepalive_is_valid(self) )
+        goto cleanup;
+
+    ++self->dka_refcount;
+
+    ref = self;
+
+cleanup:
+    return ref;
+}
+
+void
+displaykeepalive_unref(displaykeepalive_t *self)
+{
+    log_enter_function();
+
+    if( !displaykeepalive_is_valid(self) )
+        goto cleanup;
+
+    if( --self->dka_refcount != 0 )
+        goto cleanup;
+
+    displaykeepalive_dtor(self);
+    free(self);
+
+cleanup:
+    return;
+}
+
+void
+displaykeepalive_start(displaykeepalive_t *self)
+{
+    if( displaykeepalive_is_valid(self) && !self->dka_requested ) {
+        /* Set we-want-to-prevent-blanking flag */
+        self->dka_requested = true;
+
+        /* Connect to systembus */
+        displaykeepalive_dbus_connect(self);
+
+        /* Check if keepalive session can be started */
+        displaykeepalive_rethink_schedule(self);
+    }
+}
+
+void
+displaykeepalive_stop(displaykeepalive_t *self)
+{
+    if( displaykeepalive_is_valid(self) && self->dka_requested ) {
+        /* Clear we-want-to-prevent-blanking flag */
+        self->dka_requested = false;
+
+        /* Check if keepalive session needs to be stopped */
+        displaykeepalive_rethink_schedule(self);
+    }
+}

--- a/lib-glib/keepalive-displaykeepalive.h
+++ b/lib-glib/keepalive-displaykeepalive.h
@@ -1,0 +1,90 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_DISPLAYKEEPALIVE_H_
+# define KEEPALIVE_GLIB_DISPLAYKEEPALIVE_H_
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# pragma GCC visibility push(default)
+
+/** Opaque display keepalive structure
+ *
+ * Allocate via displaykeepalive_new() and
+ * release via displaykeepalive_unref().
+ */
+typedef struct displaykeepalive_t displaykeepalive_t;
+
+/** Create display keepalive object
+ *
+ * Initially has reference count of 1.
+ *
+ * Use displaykeepalive_ref() to increment reference count and
+ * displaykeepalive_unref() to decrement reference count.
+ *
+ * Will be automatically released after reference count drops to zero.
+ *
+ * @return pointer to display keepalive object
+ */
+displaykeepalive_t *displaykeepalive_new(void);
+
+/** Increment reference count of display keepalive object
+ *
+ * @return pointer to display keepalive object, or NULL in case of errors
+ */
+displaykeepalive_t *displaykeepalive_ref(displaykeepalive_t *self);
+
+/** Decrement reference count of display keepalive object
+ *
+ * The object will be released if reference count reaches zero.
+ */
+void displaykeepalive_unref(displaykeepalive_t *self);
+
+/** Disable display normal display blanking policy
+ *
+ * The display keepalive object makes the necessary dbus ipc that keeps
+ * the display from blanking while/when the following conditions are met:
+ * 1) display is already on
+ * 2) lockscreen is not shown
+ * 3) mce is running
+ */
+void displaykeepalive_start(displaykeepalive_t *self);
+
+/** Allow display normal display blanking policy
+ */
+void displaykeepalive_stop(displaykeepalive_t *self);
+
+# pragma GCC visibility pop
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif // KEEPALIVE_GLIB_DISPLAYKEEPALIVE_H_

--- a/lib-glib/keepalive-displaykeepalive.h
+++ b/lib-glib/keepalive-displaykeepalive.h
@@ -51,11 +51,15 @@ typedef struct displaykeepalive_t displaykeepalive_t;
  *
  * Will be automatically released after reference count drops to zero.
  *
- * @return pointer to display keepalive object
+ * @return pointer to display keepalive object, or NULL
  */
 displaykeepalive_t *displaykeepalive_new(void);
 
 /** Increment reference count of display keepalive object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
+ *
+ * @param self display keepalive object pointer
  *
  * @return pointer to display keepalive object, or NULL in case of errors
  */
@@ -63,7 +67,11 @@ displaykeepalive_t *displaykeepalive_ref(displaykeepalive_t *self);
 
 /** Decrement reference count of display keepalive object
  *
+ * Passing NULL object is explicitly allowed and does nothing.
+ *
  * The object will be released if reference count reaches zero.
+ *
+ * @param self display keepalive object pointer
  */
 void displaykeepalive_unref(displaykeepalive_t *self);
 

--- a/lib-glib/keepalive-glib.pc.tpl
+++ b/lib-glib/keepalive-glib.pc.tpl
@@ -1,0 +1,13 @@
+prefix={{PREFIX}}
+exec_prefix={{EXEC_PREFIX}}
+libdir={{LIBDIR}}
+# Note: Expected usage is: #include <keeaplive-glib/xxx.h>
+includedir={{INCLUDEDIR}}
+
+Name: libkeepalive-glib
+Description: Nemomobile cpu/display keepalive development files for glib apps
+Version: {{VERS}}
+Libs: -L${libdir} -lkeepalive-glib
+Libs.private: -L${libdir} -lkeepalive-glib
+Cflags: -I${includedir}
+Requires:

--- a/lib-glib/keepalive-heartbeat.c
+++ b/lib-glib/keepalive-heartbeat.c
@@ -1,0 +1,624 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "keepalive-heartbeat.h"
+
+#include "logging.h"
+
+#include <stdlib.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+
+#include <iphbd/libiphb.h>
+
+#include <glib.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+/** Memory tag for marking live heartbeat_t objects */
+#define HB_MAJICK_ALIVE 0x5492a037
+
+/** Memory tag for marking dead heartbeat_t objects */
+#define HB_MAJICK_DEAD  0x00000000
+
+/** Delay between iphb connect attempts */
+#define HB_CONNECT_TIMEOUT_MS (5 * 1000)
+
+/* Logging prefix for this module */
+#define PFIX "heartbeat: "
+
+/* ========================================================================= *
+ * TYPES
+ * ========================================================================= */
+
+struct heartbeat_t
+{
+    /** Simple memory tag to catch obviously bogus heartbeat_t pointers */
+    unsigned             hb_majick;
+
+    /** Reference count; initially 1, released when drops to 0 */
+    unsigned             hb_refcount;
+
+    /** Current minimum wakeup wait length */
+    int                  hb_delay_lo;
+
+    /** Current maximum wakeup wait length */
+    int                  hb_delay_hi;
+
+    /** Flag for: wakeup has been requested  */
+    bool                 hb_started;
+
+    /** Flag for: wakeup has been programmed */
+    bool                 hb_waiting;
+
+    /** IPHB connection handle */
+    iphb_t               hb_iphb_handle;
+
+    /** I/O watch id for hb_iphb_handle file descriptor */
+    guint                hb_wakeup_watch_id;
+
+    /** Timer id for: retrying connection attempts */
+    guint                hb_connect_timer_id;
+
+    /** User data to be passed for hb_user_notify */
+    void                *hb_user_data;
+
+    /** Free callback to be used for releasing hb_user_data */
+    heartbeat_free_fn    hb_user_free;
+
+    /** Wakeup notification callback set via heartbeat_set_notify() */
+    heartbeat_wakeup_fn  hb_user_notify;
+};
+
+/* ========================================================================= *
+ * INTERNAL FUNCTION PROTOTYPES
+ * ========================================================================= */
+
+// UTILITY
+static guint    heartbeat_add_iowatch                   (int fd, bool close_on_unref, GIOCondition cnd, GIOFunc io_cb, gpointer aptr);
+
+// CONSTRUCT_DESTRUCT
+static void     heartbeat_ctor                          (heartbeat_t *self);
+static void     heartbeat_dtor                          (heartbeat_t *self);
+static bool     heartbeat_is_valid                      (const heartbeat_t *self);
+
+// USER_DATA
+static void     heartbeat_user_data_clear               (heartbeat_t *self);
+
+// IPHB_WAKEUP
+static gboolean heartbeat_iphb_wakeup_cb                (GIOChannel *chn, GIOCondition cnd, gpointer data);
+static void     heartbeat_iphb_wakeup_schedule          (heartbeat_t *self);
+
+// IPHB_CONNECT_TIMER
+static gboolean heartbeat_iphb_connect_timer_cb         (gpointer aptr);
+static void     heartbeat_iphb_connect_timer_stop       (heartbeat_t *self);
+static void     heartbeat_iphb_connect_timer_start      (heartbeat_t *self);
+static bool     heartbeat_iphb_connect_timer_is_active  (const heartbeat_t *self);
+
+// IPHB_CONNECTION
+static bool     heartbeat_iphb_connection_try_open      (heartbeat_t *self);
+static void     heartbeat_iphb_connection_open          (heartbeat_t *self);
+static void     heartbeat_iphb_connection_close         (heartbeat_t *self);
+
+/* ========================================================================= *
+ * INTERNAL FUNCTIONS
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * UTILITY
+ * ------------------------------------------------------------------------- */
+
+/** Helper for creating I/O watch for file descriptor
+ */
+static guint
+heartbeat_add_iowatch(int fd, bool close_on_unref,
+                      GIOCondition cnd, GIOFunc io_cb, gpointer aptr)
+{
+    log_enter_function();
+
+    guint         wid = 0;
+    GIOChannel   *chn = 0;
+
+    if( !(chn = g_io_channel_unix_new(fd)) )
+        goto cleanup;
+
+    g_io_channel_set_close_on_unref(chn, close_on_unref);
+
+    cnd |= G_IO_ERR | G_IO_HUP | G_IO_NVAL;
+
+    if( !(wid = g_io_add_watch(chn, cnd, io_cb, aptr)) )
+        goto cleanup;
+
+cleanup:
+    if( chn != 0 ) g_io_channel_unref(chn);
+
+    return wid;
+
+}
+
+/* ------------------------------------------------------------------------- *
+ * CONSTRUCT_DESTRUCT
+ * ------------------------------------------------------------------------- */
+
+/** Construct heartbeat object
+ *
+ * @param self  pointer to uninitialized heartbeat object
+ */
+static void
+heartbeat_ctor(heartbeat_t *self)
+{
+    /* Mark object as valid */
+    self->hb_majick   = HB_MAJICK_ALIVE;
+
+    /* Init refcount book keeping */
+    self->hb_refcount = 1;
+
+    /* Sane default wait period */
+    self->hb_delay_lo = 60 * 60;
+    self->hb_delay_hi = 60 * 60;
+
+    /* Clear state data */
+    self->hb_started  = false;
+    self->hb_waiting  = false;
+
+    /* No iphb connection */
+    self->hb_iphb_handle      = 0;
+    self->hb_wakeup_watch_id  = 0;
+    self->hb_connect_timer_id = 0;
+
+    /* No user data */
+    self->hb_user_data   = 0;
+    self->hb_user_free   = 0;
+
+    /* No notification callback */
+    self->hb_user_notify = 0;
+}
+
+/** Destruct heartbeat object
+ *
+ * @param self  heartbeat object
+ */
+static void
+heartbeat_dtor(heartbeat_t *self)
+{
+    /* Break iphb connection */
+    heartbeat_iphb_connection_close(self);
+
+    /* Stop reconnect attempts */
+    heartbeat_iphb_connect_timer_stop(self);
+
+    /* Release user data */
+    heartbeat_user_data_clear(self);
+
+    /* Mark object as invalid */
+    self->hb_majick = HB_MAJICK_DEAD;
+}
+
+/** Predicate for: heartbeat object is valid
+ *
+ * @param self  heartbeat object
+ */
+static bool
+heartbeat_is_valid(const heartbeat_t *self)
+{
+    return self != 0 && self->hb_majick == HB_MAJICK_ALIVE;
+}
+
+/* ------------------------------------------------------------------------- *
+ * USER_DATA
+ * ------------------------------------------------------------------------- */
+
+/** Release user data
+ *
+ * @param self  heartbeat object
+ */
+static void
+heartbeat_user_data_clear(heartbeat_t *self)
+{
+    log_enter_function();
+
+    if( self->hb_user_data && self->hb_user_free )
+        self->hb_user_free(self->hb_user_data);
+
+    self->hb_user_data   = 0;
+    self->hb_user_free   = 0;
+}
+
+/* ------------------------------------------------------------------------- *
+ * IPHB_WAKEUP
+ * ------------------------------------------------------------------------- */
+
+/** Calback for handling iphb wakeups
+ *
+ * @param chn  io channel
+ * @param cnd  io condition
+ * @param data heartbeat object as void pointer
+ *
+ * @return TRUE to keep io watch alive, or FALSE to disable it
+ */
+static gboolean
+heartbeat_iphb_wakeup_cb(GIOChannel *chn,
+                         GIOCondition cnd,
+                         gpointer data)
+{
+    log_enter_function();
+
+    gboolean keep_going = FALSE;
+
+    heartbeat_t *self = data;
+
+    int fd = g_io_channel_unix_get_fd(chn);
+
+    if( fd < 0 )
+        goto cleanup_nak;
+
+    if( cnd & ~G_IO_IN )
+        goto cleanup_nak;
+
+    char buf[256];
+
+    int rc = read(fd, buf, sizeof buf);
+
+    if( rc == 0 ) {
+        log_error(PFIX"unexpected eof");
+        goto cleanup_nak;
+    }
+
+    if( rc == -1 ) {
+        if( errno == EINTR || errno == EAGAIN )
+            goto cleanup_ack;
+
+        log_error(PFIX"read error: %m");
+        goto cleanup_nak;
+    }
+
+    if( !self->hb_waiting )
+        goto cleanup_ack;
+
+    /* clear state data */
+    self->hb_started  = false;
+    self->hb_waiting  = false;
+
+    /* notify */
+    if( self->hb_user_notify )
+        self->hb_user_notify(self->hb_user_data);
+
+cleanup_ack:
+    keep_going = TRUE;
+
+cleanup_nak:
+
+    if( !keep_going ) {
+        self->hb_wakeup_watch_id = 0;
+
+        bool was_started = self->hb_started;
+        heartbeat_iphb_connection_close(self);
+
+        self->hb_started = was_started;
+        heartbeat_iphb_connection_open(self);
+    }
+
+    return keep_going;
+}
+
+/** Request iphb wakeup at currently active wakeup range/slot
+ *
+ * @param self  heartbeat object
+ */
+static void
+heartbeat_iphb_wakeup_schedule(heartbeat_t *self)
+{
+    log_enter_function();
+
+    // must be started
+    if( !self->hb_started )
+        goto cleanup;
+
+    // but not in waiting state yet
+    if( self->hb_waiting )
+        goto cleanup;
+
+    // must be connected
+    heartbeat_iphb_connection_open(self);
+    if( !self->hb_iphb_handle )
+        goto cleanup;
+
+    int lo = self->hb_delay_lo;
+    int hi = self->hb_delay_hi;
+    log_notice(PFIX"iphb_wait2(%d, %d)", lo, hi);
+    iphb_wait2(self->hb_iphb_handle, lo, hi, 0, 1);
+    self->hb_waiting = true;
+
+cleanup:
+    return;
+}
+
+/* ------------------------------------------------------------------------- *
+ * IPHB_CONNECT_TIMER
+ * ------------------------------------------------------------------------- */
+
+/** Callback for connect reattempt timer
+ *
+ * @param aptr  heartbeat object as void pointer
+ *
+ * @return TRUE to keep timer repeating, or FALSE to stop it
+ */
+static gboolean
+heartbeat_iphb_connect_timer_cb(gpointer aptr)
+{
+    heartbeat_t *self = aptr;
+
+    if( !self->hb_wakeup_watch_id )
+        goto cleanup;
+
+    log_enter_function();
+
+    if( !heartbeat_iphb_connection_try_open(self) )
+        goto cleanup;
+
+    self->hb_wakeup_watch_id = 0;
+
+    heartbeat_iphb_wakeup_schedule(self);
+
+cleanup:
+    return self->hb_wakeup_watch_id != 0;
+}
+
+/** Cancel connect reattempt timer
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static void
+heartbeat_iphb_connect_timer_stop(heartbeat_t *self)
+{
+    if( self->hb_connect_timer_id ) {
+        log_enter_function();
+
+        g_source_remove(self->hb_connect_timer_id),
+            self->hb_connect_timer_id = 0;
+    }
+}
+
+/** Start connect reattempt timer
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static void
+heartbeat_iphb_connect_timer_start(heartbeat_t *self)
+{
+    if( !self->hb_connect_timer_id ) {
+        log_enter_function();
+
+        self->hb_connect_timer_id =
+            g_timeout_add(HB_CONNECT_TIMEOUT_MS,
+                          heartbeat_iphb_connect_timer_cb,
+                          self);
+    }
+}
+
+/** Predicate for connect reattempt timer is active
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static bool
+heartbeat_iphb_connect_timer_is_active(const heartbeat_t *self)
+{
+    return self->hb_connect_timer_id != 0;
+}
+
+/* ------------------------------------------------------------------------- *
+ * IPHB_CONNECTION
+ * ------------------------------------------------------------------------- */
+
+/** Try to establish iphb socket connection now
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static bool
+heartbeat_iphb_connection_try_open(heartbeat_t *self)
+{
+    iphb_t handle = 0;
+
+    if( self->hb_iphb_handle )
+        goto cleanup;
+
+    log_enter_function();
+
+    if( !(handle = iphb_open(0)) ) {
+        log_warning(PFIX"iphb_open: %m");
+        goto cleanup;
+    }
+
+    int fd;
+
+    if( (fd = iphb_get_fd(handle)) == -1 ) {
+        log_warning(PFIX"iphb_get_fd: %m");
+        goto cleanup;
+    }
+
+    /* set up io watch */
+    self->hb_wakeup_watch_id =
+        heartbeat_add_iowatch(fd, false, G_IO_IN,
+                              heartbeat_iphb_wakeup_cb, self);
+
+    if( !self->hb_wakeup_watch_id )
+        goto cleanup;
+
+    /* heartbeat_t owns the handle */
+    self->hb_iphb_handle = handle, handle = 0;
+
+cleanup:
+
+    if( handle ) iphb_close(handle);
+
+    return self->hb_iphb_handle != 0;
+}
+
+/** Start connecting to iphb socket
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static void
+heartbeat_iphb_connection_open(heartbeat_t *self)
+{
+    log_enter_function();
+
+    if( heartbeat_iphb_connect_timer_is_active(self) ) {
+        // Retry timer already set up
+    }
+    else if( !heartbeat_iphb_connection_try_open(self) ) {
+        // Could not connect now - start retry timer
+        heartbeat_iphb_connect_timer_start(self);
+    }
+}
+
+/** Close connection to iphb socket
+ *
+ * @param aptr  heartbeat object as void pointer
+ */
+static void
+heartbeat_iphb_connection_close(heartbeat_t *self)
+{
+    log_enter_function();
+
+    /* stop iphb timer */
+    heartbeat_stop(self);
+
+    /* remove io watch */
+    if( self->hb_wakeup_watch_id ) {
+        g_source_remove(self->hb_wakeup_watch_id),
+            self->hb_wakeup_watch_id = 0;
+    }
+
+    /* close handle */
+    if( self->hb_iphb_handle ) {
+        iphb_close(self->hb_iphb_handle),
+            self->hb_iphb_handle = 0;
+    }
+}
+
+/* ========================================================================= *
+ * EXTERNAL API --  documented in: keepalive-hearbeat.h
+ * ========================================================================= */
+
+heartbeat_t *
+heartbeat_new(void)
+{
+    log_enter_function();
+
+    heartbeat_t *self = calloc(1, sizeof *self);
+
+    if( self )
+        heartbeat_ctor(self);
+
+    return self;
+}
+
+heartbeat_t *
+heartbeat_ref(heartbeat_t *self)
+{
+    log_enter_function();
+
+    if( !heartbeat_is_valid(self) )
+        return 0;
+
+    ++self->hb_refcount;
+    return self;
+}
+
+void
+heartbeat_unref(heartbeat_t *self)
+{
+    log_enter_function();
+
+    if( !heartbeat_is_valid(self) )
+        goto cleanup;
+
+    if( --self->hb_refcount > 0 )
+        goto cleanup;
+
+    heartbeat_dtor(self);
+    free(self);
+
+cleanup:
+    return;
+}
+
+void
+heartbeat_set_notify(heartbeat_t *self,
+                     heartbeat_wakeup_fn notify_cb,
+                     void *user_data,
+                     heartbeat_free_fn user_free_cb)
+{
+    log_enter_function();
+
+    heartbeat_user_data_clear(self);
+
+    self->hb_user_data   = user_data;
+    self->hb_user_free   = user_free_cb;
+
+    self->hb_user_notify = notify_cb;
+
+}
+
+void
+heartbeat_set_delay(heartbeat_t *self, int delay_lo, int delay_hi)
+{
+    log_enter_function();
+
+    if( delay_lo < 1 )
+        delay_lo = 1;
+
+    if( delay_hi < delay_lo )
+        delay_hi = delay_lo;
+
+    self->hb_delay_lo = delay_lo;
+    self->hb_delay_hi = delay_hi;
+}
+
+void
+heartbeat_start(heartbeat_t *self)
+{
+    log_enter_function();
+
+    self->hb_started = true;
+    heartbeat_iphb_wakeup_schedule(self);
+}
+
+void
+heartbeat_stop(heartbeat_t *self)
+{
+    log_enter_function();
+
+    if( self->hb_waiting && self->hb_iphb_handle )
+        iphb_wait2(self->hb_iphb_handle, 0, 0, 0, 0);
+
+    self->hb_waiting = false;
+    self->hb_started = false;
+}

--- a/lib-glib/keepalive-heartbeat.c
+++ b/lib-glib/keepalive-heartbeat.c
@@ -592,6 +592,9 @@ heartbeat_set_delay(heartbeat_t *self, int delay_lo, int delay_hi)
 {
     log_enter_function();
 
+    if( !heartbeat_is_valid(self) )
+        goto cleanup;
+
     if( delay_lo < 1 )
         delay_lo = 1;
 
@@ -600,6 +603,9 @@ heartbeat_set_delay(heartbeat_t *self, int delay_lo, int delay_hi)
 
     self->hb_delay_lo = delay_lo;
     self->hb_delay_hi = delay_hi;
+
+cleanup:
+    return;
 }
 
 void
@@ -607,8 +613,14 @@ heartbeat_start(heartbeat_t *self)
 {
     log_enter_function();
 
+    if( !heartbeat_is_valid(self) )
+        goto cleanup;
+
     self->hb_started = true;
     heartbeat_iphb_wakeup_schedule(self);
+
+cleanup:
+    return;
 }
 
 void
@@ -616,9 +628,15 @@ heartbeat_stop(heartbeat_t *self)
 {
     log_enter_function();
 
+    if( !heartbeat_is_valid(self) )
+        goto cleanup;
+
     if( self->hb_waiting && self->hb_iphb_handle )
         iphb_wait2(self->hb_iphb_handle, 0, 0, 0, 0);
 
     self->hb_waiting = false;
     self->hb_started = false;
+
+cleanup:
+    return;
 }

--- a/lib-glib/keepalive-heartbeat.h
+++ b/lib-glib/keepalive-heartbeat.h
@@ -1,0 +1,145 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_HEARTBEAT_H_
+# define KEEPALIVE_GLIB_HEARTBEAT_H_
+
+# include <stdbool.h>
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# pragma GCC visibility push(default)
+
+/** Opaque heartbeat wakeup object
+ *
+ * Allocate via heartbeat_new() and
+ * release via heartbeat_unref().
+ */
+typedef struct heartbeat_t heartbeat_t;
+
+/** Hearbeat wakeup function type
+ *
+ * @param aptr user_data set via heartbeat_set_notify()
+ */
+typedef void (*heartbeat_wakeup_fn)(void *aptr);
+
+/** User data free function type
+ *
+ * Called when heartbeat object is deleted after the
+ * final reference is dropped via heartbeat_unref(), or
+ * when heartbeat_set_notify() is called while user_data
+ * is already set.
+ *
+ * @param user_data set via heartbeat_set_notify()
+ */
+typedef void (*heartbeat_free_fn)(void *aptr);
+
+/** Create heartbeat wakeup object
+ *
+ * Initially has reference count of 1.
+ *
+ * Use heartbeat_ref() to increment reference count and
+ * heartbeat_unref() to decrement reference count.
+ *
+ * Will be automatically released after reference count drops to zero.
+ *
+ * @return pointer to heartbeat wakeup object
+ */
+heartbeat_t *heartbeat_new(void);
+
+/** Increment reference count of heartbeat wakeup object
+ *
+ * @param self heartbeat wakeup object pointer
+ *
+ * @return pointer to heartbeat wakeup object, or NULL in case of errors
+ */
+heartbeat_t *heartbeat_ref(heartbeat_t *self);
+
+/** Decrement reference count of heartbeat wakeup object
+ *
+ * The object will be released if reference count reaches zero.
+ *
+ * @param self heartbeat wakeup object pointer
+ */
+void heartbeat_unref(heartbeat_t *self);
+
+/** Set wakeup delay range
+ *
+ * If delay_lo == delay_hi, the value specifies global wakeup slot
+ * rather seconds from current time.
+ *
+ * If delay_hi < delay_lo, then the upper bound is adjusted so that
+ * it is delay_lo + heartbeat interval (=12 seconds, but may vary
+ * from one device to another).
+ *
+ * @param self      heartbeat wakeup object pointer
+ * @param delay_lo  minimum seconds to wakeup
+ * @param delay_hi  maximum seconds to wakeup
+ */
+void heartbeat_set_delay(heartbeat_t *self,
+                         int delay_lo,
+                         int delay_hi);
+
+/** Set notification callback function to use on hearbeat wakeup
+ *
+ * If non-null user_free_cb is given, it is assumed that heartbeat
+ * wakeup object owns user_data and it will be released when
+ * heartbeat object is deleted or when heartbeat_set_notify()
+ * is called again.
+ *
+ * @param self          heartbeat wakeup object pointer
+ * @param notify_cb     callback function pointer, or NULL
+ * @param user_data     data to pass to callback function
+ * @param user_free_cb  callback function for releasing user_data
+ */
+void heartbeat_set_notify(heartbeat_t *self,
+                          heartbeat_wakeup_fn notify_cb,
+                          void *user_data,
+                          heartbeat_free_fn user_free_cb);
+
+/** Start waiting for heartbeat wakeup
+ *
+ * @param self          heartbeat wakeup object pointer
+ */
+void         heartbeat_start(heartbeat_t *self);
+
+/** Cancel already scheduled heartbeat wakeup
+ *
+ * @param self          heartbeat wakeup object pointer
+ */
+void         heartbeat_stop(heartbeat_t *self);
+
+# pragma GCC visibility pop
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif /* KEEPALIVE_GLIB_HEARTBEAT_H_ */

--- a/lib-glib/keepalive-heartbeat.h
+++ b/lib-glib/keepalive-heartbeat.h
@@ -70,11 +70,13 @@ typedef void (*heartbeat_free_fn)(void *aptr);
  *
  * Will be automatically released after reference count drops to zero.
  *
- * @return pointer to heartbeat wakeup object
+ * @return pointer to heartbeat wakeup object, or NULL
  */
 heartbeat_t *heartbeat_new(void);
 
 /** Increment reference count of heartbeat wakeup object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * @param self heartbeat wakeup object pointer
  *
@@ -83,6 +85,8 @@ heartbeat_t *heartbeat_new(void);
 heartbeat_t *heartbeat_ref(heartbeat_t *self);
 
 /** Decrement reference count of heartbeat wakeup object
+ *
+ * Passing NULL object is explicitly allowed and does nothing.
  *
  * The object will be released if reference count reaches zero.
  *

--- a/lib-glib/keepalive-timeout.c
+++ b/lib-glib/keepalive-timeout.c
@@ -1,0 +1,252 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "keepalive-timeout.h"
+#include "keepalive-backgroundactivity.h"
+
+#include "logging.h"
+
+#include <stdio.h>
+
+#include <glib.h>
+
+/* ========================================================================= *
+ * CONSTANTS
+ * ========================================================================= */
+
+/* Logging prefix for this module */
+#define PFIX "timeout: "
+
+/* ========================================================================= *
+ * TYPES
+ * ========================================================================= */
+
+typedef struct keepalive_timeout_t keepalive_timeout_t;
+
+struct keepalive_timeout_t
+{
+    GSource                kat_source;
+
+    background_activity_t *kat_activity;
+    bool                   kat_triggered;
+};
+
+/* ========================================================================= *
+ * INTERNAL FUNCTION PROTOTYPES
+ * ========================================================================= */
+
+// GSOURCE_GLUE
+
+static gboolean keepalive_timeout_prepare_cb  (GSource *srce, gint *timeout);
+static gboolean keepalive_timeout_check_cb    (GSource *srce);
+static gboolean keepalive_timeout_dispatch_cb (GSource *srce, GSourceFunc cb, gpointer aptr);
+static void     keepalive_timeout_finalize_cb (GSource *srce);
+
+// BACKGROUND_ACTIVITY_GLUE
+
+static void     keepalive_timeout_trigger_cb  (background_activity_t *activity, void *aptr);
+
+/* ========================================================================= *
+ * INTERNAL FUNCTIONS
+ * ========================================================================= */
+
+/* ------------------------------------------------------------------------- *
+ * GSOURCE_GLUE
+ * ------------------------------------------------------------------------- */
+
+static
+gboolean
+keepalive_timeout_prepare_cb(GSource *srce, gint *timeout)
+{
+    keepalive_timeout_t *self = (keepalive_timeout_t *)srce;
+
+    log_enter_function();
+
+    if( self->kat_triggered )
+        return *timeout = 0, TRUE;
+
+    return *timeout = -1, FALSE;
+}
+
+static
+gboolean
+keepalive_timeout_check_cb(GSource *srce)
+{
+    keepalive_timeout_t *self = (keepalive_timeout_t *)srce;
+
+    log_enter_function();
+
+    return self->kat_triggered;
+}
+
+static
+gboolean
+keepalive_timeout_dispatch_cb(GSource *srce, GSourceFunc cb, gpointer aptr)
+{
+    keepalive_timeout_t *self = (keepalive_timeout_t *)srce;
+
+    log_enter_function();
+
+    bool repeat = cb(aptr);
+
+    if( repeat )
+        background_activity_wait(self->kat_activity);
+    else
+        background_activity_stop(self->kat_activity);
+
+    self->kat_triggered = false;
+
+    return repeat;
+}
+
+static
+void
+keepalive_timeout_finalize_cb(GSource *srce)
+{
+    keepalive_timeout_t *self = (keepalive_timeout_t *)srce;
+
+    log_enter_function();
+
+    background_activity_unref(self->kat_activity),
+        self->kat_activity = 0;
+}
+
+static GSourceFuncs keepalive_timeout_funcs =
+{
+    .prepare  = keepalive_timeout_prepare_cb,
+    .check    = keepalive_timeout_check_cb,
+    .dispatch = keepalive_timeout_dispatch_cb,
+    .finalize = keepalive_timeout_finalize_cb,
+};
+
+/* ------------------------------------------------------------------------- *
+ * BACKGROUND_ACTIVITY_GLUE
+ * ------------------------------------------------------------------------- */
+
+static
+void
+keepalive_timeout_trigger_cb(background_activity_t *activity, void *aptr)
+{
+    (void)activity;
+
+    log_enter_function();
+
+    keepalive_timeout_t *self = aptr;
+
+    /* What happens here is:
+     * 1) the io watch for iphb connection caused this function to get called
+     * 2) we mark the timer to be in triggered state
+     * 3) either prepare or check probe is called before glib mainloop
+     *    goes to select again
+     * 4) which then causes dispatch callback invocation
+     * 5) dispatch function
+     *      starts keepalive session
+     *      calls timer callback, and based on return value
+     *      restarts/stops background activity
+     */
+    self->kat_triggered = true;
+}
+
+/* ========================================================================= *
+ * EXTERNAL API --  documented in: keepalive-timeout.h
+ * ========================================================================= */
+
+guint
+keepalive_timeout_add_full(gint priority,
+                           guint interval,
+                           GSourceFunc func,
+                           gpointer data,
+                           GDestroyNotify notify)
+{
+    guint id = 0;
+
+    keepalive_timeout_t *self = (keepalive_timeout_t *)
+        g_source_new(&keepalive_timeout_funcs, sizeof *self);
+
+    if( !self )
+        goto cleanup;
+
+    self->kat_activity  = background_activity_new();
+    self->kat_triggered = false;
+
+    background_activity_set_running_callback(self->kat_activity,
+                                             keepalive_timeout_trigger_cb);
+    background_activity_set_user_data(self->kat_activity,
+                                      self, 0);
+
+    /* Minimum wait as requested */
+    int delay_lo = (interval + 999) / 1000;
+
+    /* Default to: let background object decide maximum wait */
+    int delay_hi = -1;
+
+    if( priority <= G_PRIORITY_HIGH ) {
+        /* Use tighter wakeup range for high priority timeouts */
+        delay_hi = delay_lo + 1;
+    }
+
+    background_activity_set_wakeup_range(self->kat_activity,
+                                         delay_lo, delay_hi);
+    background_activity_wait(self->kat_activity);
+
+    g_source_set_callback((GSource*)self, func, data, notify);
+    id = g_source_attach((GSource*)self, 0);
+
+cleanup:
+    if( self )
+        g_source_unref((GSource*)self);
+
+    return id;
+}
+
+guint
+keepalive_timeout_add(guint interval,
+                      GSourceFunc function,
+                      gpointer data)
+{
+    return keepalive_timeout_add_full(G_PRIORITY_DEFAULT, interval,
+                                      function, data, 0);
+}
+
+guint
+keepalive_timeout_add_seconds_full(gint priority,
+                                   guint interval,
+                                   GSourceFunc function,
+                                   gpointer data,
+                                   GDestroyNotify notify)
+{
+    return keepalive_timeout_add_full(priority, interval * 1000,
+                                      function, data, notify);
+}
+
+guint
+keepalive_timeout_add_seconds(guint interval,
+                              GSourceFunc function,
+                              gpointer data)
+{
+    return keepalive_timeout_add_full(G_PRIORITY_DEFAULT, interval * 1000,
+                                      function, data, 0);
+}

--- a/lib-glib/keepalive-timeout.h
+++ b/lib-glib/keepalive-timeout.h
@@ -1,0 +1,124 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_TIMEOUT_H_
+# define KEEPALIVE_GLIB_TIMEOUT_H_
+
+# include <glib.h>
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# pragma GCC visibility push(default)
+
+/** Drop in replacement for g_timeout_add_full()
+ *
+ * Unlike normal glib timers, these can wake the device from suspend and
+ * keep the device from suspending while the callback function is executed
+ * by using iphb wakeups from dsme and cpu keepalive from mce.
+ *
+ * Note that the wakeup time is not exact.
+ *
+ * The iphb wakeups use 1 second resolution, so the milliseconds used
+ * due to following the glib interface are rounded up to the next full
+ * second.
+ *
+ * If the device needs to wake up from suspend, that happens via RTC
+ * alarm interrupts. In that case clock source differences can cause
+ * up to one second jitter in wakeups.
+ *
+ * And the triggering is scheduled via ranged iphb wakeup. By default the
+ * range that is used is [interval, interval + heartbeat seconds] - which
+ * should guarantee that the device will not wake up solely to serve the
+ * timer, but also means the wakeup can occur up to 12 seconds later than
+ * requested.
+ *
+ * If more exact wakeup is absolutely required, the priority parameter
+ * of G_PRIORITY_HIGH can be used and the wakeup is scheduled to occur
+ * at range of [interval, interval + 1 second].
+ *
+ * @param priority  the priority of the timeout source. Typically this
+ *                  will be in the range between G_PRIORITY_DEFAULT and
+ *                  G_PRIORITY_HIGH.
+ * @param interval  the time between calls to the function, in milliseconds
+ * @param function  function to call
+ * @param data      data to pass to function
+ * @param notify    function to call when the timeout is removed, or NULL.
+ *
+ * @return the ID (greater than 0) of the event source
+ */
+guint keepalive_timeout_add_full(gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify);
+
+/** Drop in replacement for g_timeout_add()
+ *
+ * See g_timeout_add_full() for details.
+ *
+ * @param interval  the time between calls to the function, in milliseconds
+ * @param function  function to call
+ * @param data      data to pass to function
+ *
+ * @return the ID (greater than 0) of the event source
+ */
+guint keepalive_timeout_add(guint interval, GSourceFunc function, gpointer data);
+
+/** Drop in replacement for g_timeout_add_seconds_full()
+ *
+ * See g_timeout_add_full() for details.
+ *
+ * @param priority  the priority of the timeout source. Typically this
+ *                  will be in the range between G_PRIORITY_DEFAULT and
+ *                  G_PRIORITY_HIGH.
+ * @param interval  the time between calls to the function, in seconds
+ * @param function  function to call
+ * @param data      data to pass to function
+ * @param notify    function to call when the timeout is removed, or NULL.
+ *
+ * @return the ID (greater than 0) of the event source
+ */
+guint keepalive_timeout_add_seconds_full(gint priority, guint interval, GSourceFunc function, gpointer data, GDestroyNotify notify);
+
+/** Drop in replacement for g_timeout_add_seconds()
+ *
+ * See g_timeout_add_full() for details.
+ *
+ * @param interval  the time between calls to the function, in seconds
+ * @param function  function to call
+ * @param data      data to pass to function
+ *
+ * @return the ID (greater than 0) of the event source
+ */
+guint keepalive_timeout_add_seconds(guint interval, GSourceFunc function, gpointer data);
+
+# pragma GCC visibility pop
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif /* KEEPALIVE_GLIB_TIMEOUT_H_ */

--- a/lib-glib/keepalive.h
+++ b/lib-glib/keepalive.h
@@ -1,0 +1,46 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_KEEPALIVE_H_
+# define KEEPALIVE_GLIB_KEEPALIVE_H_
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+# include "keepalive-heartbeat.h"
+# include "keepalive-cpukeepalive.h"
+# include "keepalive-displaykeepalive.h"
+# include "keepalive-backgroundactivity.h"
+# include "keepalive-timeout.h"
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif /* KEEPALIVE_GLIB_KEEPALIVE_H_ */

--- a/lib-glib/logging.c
+++ b/lib-glib/logging.c
@@ -1,0 +1,121 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "logging.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdarg.h>
+#include <errno.h>
+
+static int log_verbosity = LOGGING_DEFAULT_LEVEL;
+
+static const char *
+log_prefix(int lev)
+{
+    const char *res = "?";
+
+    switch( lev ) {
+    case LOG_EMERG:     res = "X"; break;
+    case LOG_ALERT:     res = "A"; break;
+    case LOG_CRIT:      res = "C"; break;
+    case LOG_ERR:       res = "E"; break;
+    case LOG_WARNING:   res = "W"; break;
+    case LOG_NOTICE:    res = "N"; break;
+    case LOG_INFO:      res = "I"; break;
+    case LOG_DEBUG:     res = "D"; break;
+    }
+
+    return res;
+}
+
+void
+log_set_verbosity(int lev)
+{
+    if( lev < LOG_ERR )
+        lev = LOG_ERR;
+
+    if( lev > LOG_DEBUG )
+        lev = LOG_DEBUG;
+
+    log_verbosity = lev;
+}
+
+int
+log_get_verbosity(void)
+{
+    return log_verbosity;
+}
+
+bool
+log_p(int lev)
+{
+    /* NOTE: Code must not change errno */
+    return lev <= log_verbosity;
+}
+
+void
+log_emit_(int lev, const char *fmt, ...)
+{
+    /* Mark down errno on entry */
+    int   saved = errno;
+
+    char *text = 0;
+
+    /* Check verbosity also here in case log_xxx() macros
+     * were not used by the calling code */
+    if( !log_p(lev) )
+        goto cleanup;
+
+    va_list va;
+
+    va_start(va, fmt);
+    int rc = vasprintf(&text, fmt, va);
+    va_end(va);
+
+    if( rc < 0 ) {
+        text = 0;
+        goto cleanup;
+    }
+
+    fprintf(stderr, "keepalive: %s: %s\n", log_prefix(lev), text);
+
+cleanup:
+
+    free(text);
+
+    /* Restore errno before returning */
+    errno = saved;
+}
+
+static void log_init(void) __attribute__((constructor));
+
+static void log_init(void)
+{
+    const char *env = getenv("LIBKEEPALIVE_VERBOSITY");
+    if( env != 0 )
+        log_set_verbosity(strtol(env, 0, 0));
+}

--- a/lib-glib/logging.h
+++ b/lib-glib/logging.h
@@ -1,0 +1,118 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+/* NOTE: Internal to libkeepalive-glib
+ *
+ * These functions are not exported and the header must not
+ * be included in the devel package
+ */
+
+#ifndef KEEPALIVE_GLIB_LOGGING_H_
+# define KEEPALIVE_GLIB_LOGGING_H_
+
+# include <stdbool.h>
+# include <syslog.h>
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+/** Default logging verbosity to enable */
+# ifndef LOGGING_DEFAULT_LEVEL
+#  define LOGGING_DEFAULT_LEVEL LOG_WARNING
+# endif
+
+/** Default logging level to compile in */
+# ifndef LOGGING_BUILD_LEVEL
+#  define LOGGING_BUILD_LEVEL LOG_DEBUG
+# endif
+
+/** Default function entry logging */
+# ifndef LOGGING_TRACE_FUNCTIONS
+#  define LOGGING_TRACE_FUNCTIONS 0
+# endif
+
+void log_set_verbosity(int lev);
+int  log_get_verbosity(void);
+
+bool log_p(int lev);
+
+void log_emit_(int lev, const char *fmt, ...) __attribute__((format(printf, 2, 3)));
+
+#define log_emit(LEV, FMT, ARGS...) do { \
+    if( log_p(LEV) )\
+        log_emit_(LEV, FMT, ## ARGS);\
+} while(0)
+
+# if LOGGING_BUILD_LEVEL >= LOG_CRIT
+#  define log_crit(   FMT, ARGS...) log_emit(LOG_CRIT, FMT, ## ARGS)
+# else
+#  define log_crit(   FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_BUILD_LEVEL >= LOG_ERR
+#  define log_error(  FMT, ARGS...) log_emit(LOG_ERR, FMT, ## ARGS)
+# else
+#  define log_error(  FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_BUILD_LEVEL >= LOG_WARNING
+#  define log_warning(FMT, ARGS...) log_emit(LOG_WARNING, FMT, ## ARGS)
+# else
+#  define log_warning(FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_BUILD_LEVEL >= LOG_NOTICE
+#  define log_notice( FMT, ARGS...) log_emit(LOG_NOTICE, FMT, ## ARGS)
+# else
+#  define log_notice( FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_BUILD_LEVEL >= LOG_INFO
+#  define log_info(   FMT, ARGS...) log_emit(LOG_INFO, FMT, ## ARGS)
+# else
+#  define log_info(   FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_BUILD_LEVEL >= LOG_DEBUG
+#  define log_debug(  FMT, ARGS...) log_emit(LOG_DEBUG, FMT, ## ARGS)
+# else
+#  define log_debug(  FMT, ARGS...) do { } while( 0 )
+# endif
+
+# if LOGGING_TRACE_FUNCTIONS
+#  define log_enter_function() log_debug("@%s() ...", __FUNCTION__)
+#else
+#  define log_enter_function() do { } while( 0 )
+#endif
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif /* KEEPALIVE_GLIB_LOGGING_H_ */

--- a/lib-glib/xdbus.c
+++ b/lib-glib/xdbus.c
@@ -139,7 +139,7 @@ xdbus_method_call(DBusConnection *con,
 
 /** Helper for making async dbus method calls without waiting for reply
  */
- void
+void
 xdbus_simple_call(DBusConnection *con,
                   const char *service,
                   const char *object,

--- a/lib-glib/xdbus.c
+++ b/lib-glib/xdbus.c
@@ -1,0 +1,163 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#include "xdbus.h"
+#include "logging.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+
+#include <glib.h>
+
+/* Logging prefix for this module */
+#define PFIX "dbus: "
+
+/** Predicate for: connection is not null and in connected state
+ */
+bool
+xdbus_connection_is_valid(DBusConnection *con)
+{
+    return con && dbus_connection_get_is_connected(con);
+}
+
+/** Helper for making asynchronous dbus method calls; varargs version
+ */
+DBusPendingCall *
+xdbus_method_call_va(DBusConnection *con,
+                     const char *service,
+                     const char *object,
+                     const char *interface,
+                     const char *method,
+                     DBusPendingCallNotifyFunction notify_cb,
+                     void *data,
+                     DBusFreeFunction free_cb,
+                     int arg_type,
+                     va_list va)
+{
+    DBusPendingCall  *res = 0;
+    DBusPendingCall  *pc  = 0;
+    DBusMessage      *req = 0;
+
+    if( !xdbus_connection_is_valid(con) )
+        goto cleanup;
+
+    req = dbus_message_new_method_call(service, object, interface, method);
+    if( !req )
+        goto cleanup;
+
+    if( arg_type != DBUS_TYPE_INVALID &&
+        !dbus_message_append_args_valist(req, arg_type, va) )
+        goto cleanup;
+
+    log_notice(PFIX"calling method: %s.%s", interface, method);
+
+    if( !notify_cb ) {
+        dbus_message_set_no_reply(req, TRUE);
+        dbus_connection_send(con, req, 0);
+        goto cleanup;
+    }
+
+    if( !dbus_connection_send_with_reply(con, req, &pc, -1) )
+        goto cleanup;
+
+    if( !pc )
+        goto cleanup;
+
+    if( !dbus_pending_call_set_notify(pc, notify_cb, data, free_cb) )
+        goto cleanup;
+
+    // notify owns the data
+    free_cb = 0, data = 0;
+
+    // notification holds ref to pending call
+    res = pc;
+
+cleanup:
+
+    if( data && free_cb )
+        free_cb(data);
+
+    if( pc )
+        dbus_pending_call_unref(pc);
+
+    if( req )
+        dbus_message_unref(req);
+
+    return res;
+}
+
+/** Helper for making asynchronous dbus method calls
+ */
+DBusPendingCall *
+xdbus_method_call(DBusConnection *con,
+                  const char *service,
+                  const char *object,
+                  const char *interface,
+                  const char *method,
+                  DBusPendingCallNotifyFunction notify_cb,
+                  void *data,
+                  DBusFreeFunction free_cb,
+                  int arg_type,
+                  ...)
+{
+    DBusPendingCall *res = 0;
+
+    va_list va;
+
+    va_start(va, arg_type);
+    res = xdbus_method_call_va(con, service, object, interface, method,
+                               notify_cb, data, free_cb, arg_type, va);
+    va_end(va);
+
+    return res;
+}
+
+/** Helper for making async dbus method calls without waiting for reply
+ */
+ void
+xdbus_simple_call(DBusConnection *con,
+                  const char *service,
+                  const char *object,
+                  const char *interface,
+                  const char *method,
+                  int arg_type,
+                  ...)
+{
+    DBusPendingCall *res = 0;
+
+    va_list va;
+
+    va_start(va, arg_type);
+    res = xdbus_method_call_va(con, service, object, interface, method,
+                               0, 0, 0, arg_type, va);
+    va_end(va);
+
+    /* Note: this should never happen */
+    if( res )
+        dbus_pending_call_cancel(res);
+}

--- a/lib-glib/xdbus.h
+++ b/lib-glib/xdbus.h
@@ -1,0 +1,54 @@
+/****************************************************************************************
+**
+** Copyright (C) 2014 Jolla Ltd.
+** Contact: Simo Piiroinen <simo.piiroinen@jollamobile.com>
+** All rights reserved.
+**
+** This file is part of nemo keepalive package.
+**
+** You may use this file under the terms of the GNU Lesser General
+** Public License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is free software; you can redistribute it and/or
+** modify it under the terms of the GNU Lesser General Public
+** License version 2.1 as published by the Free Software Foundation
+** and appearing in the file license.lgpl included in the packaging
+** of this file.
+**
+** This library is distributed in the hope that it will be useful,
+** but WITHOUT ANY WARRANTY; without even the implied warranty of
+** MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+** Lesser General Public License for more details.
+**
+****************************************************************************************/
+
+#ifndef KEEPALIVE_GLIB_XDBUS_H_
+# define KEEPALIVE_GLIB_XDBUS_H_
+
+#include <stdbool.h>
+#include <dbus/dbus.h>
+
+# ifdef __cplusplus
+extern "C" {
+# elif 0
+} /* fool JED indentation ... */
+# endif
+
+/* Internal to libkeepalive-glib - documented at source code
+ *
+ * These functions are not exported and the header must not
+ * be included in the devel package
+ */
+
+bool             xdbus_connection_is_valid (DBusConnection *con);
+DBusPendingCall *xdbus_method_call_va      (DBusConnection *con, const char *service, const char *object, const char *interface, const char *method, DBusPendingCallNotifyFunction notify_cb, void *data, DBusFreeFunction free_cb, int arg_type, va_list va);
+DBusPendingCall *xdbus_method_call         (DBusConnection *con, const char *service, const char *object, const char *interface, const char *method, DBusPendingCallNotifyFunction notify_cb, void *data, DBusFreeFunction free_cb, int arg_type, ...);
+void             xdbus_simple_call         (DBusConnection *con, const char *service, const char *object, const char *interface, const char *method, int arg_type, ...);
+
+# ifdef __cplusplus
+};
+# endif
+
+#endif // KEEPALIVE_GLIB_XDBUS_H_

--- a/rpm/keepalive.spec
+++ b/rpm/keepalive.spec
@@ -34,7 +34,7 @@ make -C lib-glib %{?jobs:-j%jobs}
 %install
 rm -rf %{buildroot}
 make install INSTALL_ROOT=%{buildroot}
-make -C lib-glib install ROOT=%{buildroot}
+make -C lib-glib install ROOT=%{buildroot} VERS=%{version}
 
 %post -p /sbin/ldconfig
 

--- a/rpm/keepalive.spec
+++ b/rpm/keepalive.spec
@@ -32,7 +32,7 @@ CPU and display keepalive and scheduling library
 %build
 %qmake5
 make %{?jobs:-j%jobs}
-make -C lib-glib %{?jobs:-j%jobs}
+make -C lib-glib %{?jobs:-j%jobs} VERS=%{version}
 
 %install
 rm -rf %{buildroot}

--- a/rpm/keepalive.spec
+++ b/rpm/keepalive.spec
@@ -16,7 +16,7 @@ BuildRequires:  pkgconfig(Qt5Gui)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Test)
-BuildRequires:  mce-headers
+BuildRequires:  pkgconfig(mce)
 BuildRequires:  pkgconfig(dsme) >= 0.58
 BuildRequires:  pkgconfig(libiphb) >= 1.2.0
 
@@ -29,10 +29,12 @@ CPU and display keepalive and scheduling library
 %build
 %qmake5
 make %{?jobs:-j%jobs}
+make -C lib-glib %{?jobs:-j%jobs}
 
 %install
 rm -rf %{buildroot}
 make install INSTALL_ROOT=%{buildroot}
+make -C lib-glib install ROOT=%{buildroot}
 
 %post -p /sbin/ldconfig
 
@@ -40,7 +42,7 @@ make install INSTALL_ROOT=%{buildroot}
 
 %files
 %defattr(-,root,root,-)
-%{_libdir}/lib*.so.*
+%{_libdir}/libkeepalive.so.*
 %dir %{_libdir}/qt5/qml/org/nemomobile
 %{_libdir}/qt5/qml/org/nemomobile/*
 
@@ -55,7 +57,7 @@ Development package for CPU and display keepalive and scheduling library
 
 %files devel
 %defattr(-,root,root,-)
-%{_libdir}/lib*.so
+%{_libdir}/libkeepalive.so
 %{_libdir}/pkgconfig/keepalive.pc
 %dir %{_includedir}/keepalive
 %{_includedir}/keepalive/*.h
@@ -86,4 +88,36 @@ Requires:   %{name} = %{version}-%{release}
 %files tests
 %defattr(-,root,root,-)
 /opt/tests/nemo-keepalive/*
+
+#----------------------------------------------------------------
+%package glib
+Summary:    CPU and display keepalive and scheduling library
+Group:      System/System Control
+
+%description glib
+CPU and display keepalive and scheduling library
+
+%post glib -p /sbin/ldconfig
+
+%postun glib -p /sbin/ldconfig
+
+%files glib
+%defattr(-,root,root,-)
+%{_libdir}/libkeepalive-glib.so.*
+
+#----------------------------------------------------------------
+%package glib-devel
+Summary:    Development headers for libkeepalive for use with glib
+Group:      Development/Libraries
+Requires:   %{name}-glib = %{version}-%{release}
+
+%description glib-devel
+Development package for CPU and display keepalive and scheduling library
+
+%files glib-devel
+%defattr(-,root,root,-)
+%{_libdir}/libkeepalive-glib.so
+%{_libdir}/pkgconfig/keepalive-glib.pc
+%dir %{_includedir}/keepalive-glib
+%{_includedir}/keepalive-glib/*.h
 

--- a/rpm/keepalive.spec
+++ b/rpm/keepalive.spec
@@ -19,6 +19,9 @@ BuildRequires:  pkgconfig(Qt5Test)
 BuildRequires:  pkgconfig(mce)
 BuildRequires:  pkgconfig(dsme) >= 0.58
 BuildRequires:  pkgconfig(libiphb) >= 1.2.0
+BuildRequires:  pkgconfig(glib-2.0)
+BuildRequires:  pkgconfig(dbus-1)
+BuildRequires:  pkgconfig(dbus-glib-1)
 
 %description
 CPU and display keepalive and scheduling library


### PR DESCRIPTION
Originally keepalive functionality was written with only Qt and
QML applications in mind. This meant that system daemons and
middleware components that need to deal with waking up from suspend
and/or staying out of suspend had to use lower level services directly.

Implement feature-wise similar interface for use from glib based
programs as what is available for Qt/QML applications.

Interfaces provided:
* keepalive-displaykeepalive.h disable based display dimming/blanking
* keepalive-cpukeepalive.h disable autosuspend policy
* keepalive-heartbeat.h wake up from suspend via iphb service
* keepalive-backgroundactivity.h periodic wakeups with suspend blocking
* keepalive-timeout.h suspend aware g_timeout_add like functionality

Also includes simple example applications.